### PR TITLE
Initial support sending logs to user

### DIFF
--- a/.github/workflows/clippy-rustfmt.yml
+++ b/.github/workflows/clippy-rustfmt.yml
@@ -28,4 +28,4 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: cargo clippy
-        run: cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 *.swp
+tags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.75"
 [workspace.dependencies]
 serde = { version = "1.0.144", features = ["derive"] }
 env_logger = "0.9.0"
-log = "0.4.17"
+log = { version = "0.4.17", features = ["std"] }
 serde_json = "1.0.87"
 serde_yaml = "0.9.27"
 uuid = { version = "1.6.1", default-features = false, features = ["std", "v7"] }

--- a/src/cli/nipc.rs
+++ b/src/cli/nipc.rs
@@ -107,7 +107,7 @@ async fn main() -> Result<(), CliError> {
         .get_matches();
 
     let mut log_builder = env_logger::Builder::new();
-    log_builder.filter(Some("nipart"), log::LevelFilter::Info);
+    log_builder.filter(Some("nipart"), log::LevelFilter::Debug);
     log_builder.filter(None, log::LevelFilter::Debug);
     log_builder.init();
 

--- a/src/lib/ipc.rs
+++ b/src/lib/ipc.rs
@@ -287,9 +287,12 @@ impl NipartConnection {
         Ok(())
     }
 
-    /// Since daemon is working asynchronously, recv() might receive
-    /// message we are not interested, this function will only store
-    /// irrelevant reply to internal buffer.
+    /// Since daemon is working asynchronously and client might send multiple
+    /// requests via single connection, recv() might receive message we are not
+    /// interested, this function will only store irrelevant reply to internal
+    /// buffer.
+    /// When multiple requests invoked on single connection, the log will
+    /// be mixed.
     ///
     /// # Returns
     ///  * Function will return when a matching event received.
@@ -313,6 +316,10 @@ impl NipartConnection {
                 .await
                 {
                     Ok(Ok(event)) => {
+                        if event.is_log() {
+                            event.emit_log();
+                            continue;
+                        }
                         let elapsed = now.elapsed();
                         if elapsed >= remain_time {
                             remain_time = Duration::ZERO;

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -9,8 +9,10 @@ mod lock;
 mod logging;
 mod monitor;
 mod plugin;
+pub(crate) mod plugin_common;
+mod plugin_external;
 mod plugin_ipc;
-mod plugin_trait;
+mod plugin_native;
 mod state_options;
 // TODO: Currently we are copy code from nmstate, hence suppressed warnings,
 //       Need to clean up the code once detached from nmstate code base
@@ -26,14 +28,15 @@ pub use self::error::{ErrorKind, NipartError};
 pub use self::event::{NipartEvent, NipartEventAddress, NipartUserEvent};
 pub use self::ipc::{NipartConnection, DEFAULT_TIMEOUT};
 pub use self::lock::{NipartLockEntry, NipartLockOption};
-pub use self::logging::NipartLogLevel;
+pub use self::logging::{NipartLogEntry, NipartLogLevel};
 pub use self::monitor::{
     NipartAddressMonitorKind, NipartAddressMonitorRule, NipartLinkMonitorKind,
     NipartLinkMonitorRule, NipartMonitorEvent, NipartMonitorRule,
 };
 pub use self::plugin::{NipartPluginEvent, NipartPluginInfo, NipartRole};
+pub use self::plugin_external::{NipartExternalPlugin, NipartPluginRunner};
 pub use self::plugin_ipc::NipartConnectionListener;
-pub use self::plugin_trait::{NipartExternalPlugin, NipartNativePlugin};
+pub use self::plugin_native::NipartNativePlugin;
 pub use self::state_options::{NipartApplyOption, NipartQueryOption};
 
 // TODO Please remove this * once we detached from nmstate code base

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{ErrorKind, NipartError};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize,
+)]
 #[repr(usize)]
 #[serde(rename_all = "lowercase")]
 pub enum NipartLogLevel {
@@ -19,12 +21,12 @@ pub enum NipartLogLevel {
 impl NipartLogLevel {
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Off => "off",
-            Self::Error => "error",
-            Self::Warn => "warn",
-            Self::Info => "info",
-            Self::Debug => "debug",
-            Self::Trace => "trace",
+            Self::Off => "OFF",
+            Self::Error => "ERROR",
+            Self::Warn => "WARN",
+            Self::Info => "INFO",
+            Self::Debug => "DEBUG",
+            Self::Trace => "TRACE",
         }
     }
 }
@@ -101,6 +103,40 @@ impl std::str::FromStr for NipartLogLevel {
                 ErrorKind::InvalidArgument,
                 format!("Invalid logging level {s}"),
             )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub struct NipartLogEntry {
+    pub level: NipartLogLevel,
+    pub message: String,
+}
+
+impl NipartLogEntry {
+    pub fn new(level: NipartLogLevel, message: String) -> Self {
+        Self { level, message }
+    }
+
+    pub fn emit_log(&self, source: &str) {
+        match self.level {
+            NipartLogLevel::Off => (),
+            NipartLogLevel::Error => {
+                log::error!(target: source, "{}", self.message)
+            }
+            NipartLogLevel::Warn => {
+                log::warn!(target: source, "{}", self.message)
+            }
+            NipartLogLevel::Info => {
+                log::info!(target: source, "{}", self.message)
+            }
+            NipartLogLevel::Debug => {
+                log::debug!(target: source, "{}", self.message)
+            }
+            NipartLogLevel::Trace => {
+                log::trace!(target: source, "{}", self.message)
+            }
         }
     }
 }

--- a/src/lib/plugin.rs
+++ b/src/lib/plugin.rs
@@ -38,6 +38,7 @@ pub enum NipartRole {
     Monitor,
     Track,
     Locker,
+    Logger,
 }
 
 impl std::fmt::Display for NipartRole {
@@ -54,6 +55,7 @@ impl std::fmt::Display for NipartRole {
                 Self::Track => "track",
                 Self::ApplyDhcpLease => "apply_dhcp_lease",
                 Self::Locker => "locker",
+                Self::Logger => "logger",
             }
         )
     }

--- a/src/lib/plugin_common.rs
+++ b/src/lib/plugin_common.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    NipartEvent, NipartEventAddress, NipartLogLevel, NipartPluginEvent,
+    NipartPluginInfo, NipartUserEvent,
+};
+
+pub(crate) fn handle_query_plugin_info(
+    uuid: u128,
+    src: &NipartEventAddress,
+    plugin_info: NipartPluginInfo,
+    plugin_name: &str,
+) -> NipartEvent {
+    log::debug!("Querying plugin info of {}", plugin_name);
+    NipartEvent::new_with_uuid(
+        uuid,
+        NipartUserEvent::None,
+        NipartPluginEvent::QueryPluginInfoReply(plugin_info),
+        NipartEventAddress::Unicast(plugin_name.to_string()),
+        src.clone(),
+        crate::DEFAULT_TIMEOUT,
+    )
+}
+
+pub(crate) fn handle_change_log_level(
+    log_level: NipartLogLevel,
+    uuid: u128,
+    plugin_name: &str,
+) -> NipartEvent {
+    log::debug!("Setting log level of {} to {log_level}", plugin_name);
+    log::set_max_level(log_level.into());
+    NipartEvent::new_with_uuid(
+        uuid,
+        NipartUserEvent::None,
+        NipartPluginEvent::QueryLogLevelReply(log_level),
+        NipartEventAddress::Unicast(plugin_name.to_string()),
+        NipartEventAddress::Commander,
+        crate::DEFAULT_TIMEOUT,
+    )
+}
+
+pub(crate) fn handle_query_log_level(
+    uuid: u128,
+    plugin_name: &str,
+) -> NipartEvent {
+    log::debug!("Querying log level of {}", plugin_name);
+    NipartEvent::new_with_uuid(
+        uuid,
+        NipartUserEvent::None,
+        NipartPluginEvent::QueryLogLevelReply(log::max_level().into()),
+        NipartEventAddress::Unicast(plugin_name.to_string()),
+        NipartEventAddress::Commander,
+        crate::DEFAULT_TIMEOUT,
+    )
+}

--- a/src/lib/plugin_native.rs
+++ b/src/lib/plugin_native.rs
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::future::Future;
+
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use crate::{
+    NipartError, NipartEvent, NipartEventAddress, NipartLogEntry,
+    NipartLogLevel, NipartPluginEvent, NipartPluginInfo, NipartRole,
+    NipartUserEvent,
+};
+
+pub trait NipartNativePlugin: Sized + Send + Sync + 'static {
+    const PLUGIN_NAME: &'static str;
+
+    fn sender_to_daemon(&self) -> &Sender<NipartEvent>;
+
+    fn recver_from_daemon(&mut self) -> &mut Receiver<NipartEvent>;
+
+    fn roles() -> Vec<NipartRole>;
+
+    fn get_log_level(&self) -> NipartLogLevel;
+
+    fn set_log_level(&mut self, level: NipartLogLevel);
+
+    // TODO: Use macro to create a wrapper like log_debug!()
+    fn log(
+        &self,
+        level: NipartLogLevel,
+        uuid: u128,
+        msg: String,
+    ) -> impl Future<Output = ()> + Send {
+        async move {
+            if level > self.get_log_level() {
+                return;
+            }
+
+            if uuid > 0 {
+                let event = NipartEvent::new_with_uuid(
+                    uuid,
+                    NipartUserEvent::Log(NipartLogEntry::new(level, msg)),
+                    NipartPluginEvent::None,
+                    NipartEventAddress::Unicast(Self::PLUGIN_NAME.to_string()),
+                    NipartEventAddress::User,
+                    crate::DEFAULT_TIMEOUT,
+                );
+                event.emit_log();
+                if let Err(e) = self.sender_to_daemon().send(event).await {
+                    log::error!(
+                        "{level} plugin::{} {uuid}: \
+                        Failed to send log to daemon, {e}",
+                        Self::PLUGIN_NAME,
+                    );
+                }
+            }
+        }
+    }
+
+    fn plugin_info() -> NipartPluginInfo {
+        NipartPluginInfo {
+            name: Self::PLUGIN_NAME.to_string(),
+            roles: Self::roles(),
+        }
+    }
+
+    fn init(
+        log_level: NipartLogLevel,
+        to_daemon: Sender<NipartEvent>,
+        from_daemon: Receiver<NipartEvent>,
+    ) -> impl Future<Output = Result<Self, NipartError>> + Send;
+
+    fn handle_query_plugin_info(
+        uuid: u128,
+        src: &NipartEventAddress,
+    ) -> NipartEvent {
+        crate::plugin_common::handle_query_plugin_info(
+            uuid,
+            src,
+            Self::plugin_info(),
+            Self::PLUGIN_NAME,
+        )
+    }
+
+    fn handle_change_log_level(
+        &mut self,
+        log_level: NipartLogLevel,
+        uuid: u128,
+    ) -> NipartEvent {
+        self.set_log_level(log_level);
+
+        NipartEvent::new_with_uuid(
+            uuid,
+            NipartUserEvent::None,
+            NipartPluginEvent::QueryLogLevelReply(log_level),
+            NipartEventAddress::Unicast(Self::PLUGIN_NAME.to_string()),
+            NipartEventAddress::Commander,
+            crate::DEFAULT_TIMEOUT,
+        )
+    }
+
+    fn handle_query_log_level(uuid: u128) -> NipartEvent {
+        crate::plugin_common::handle_query_log_level(uuid, Self::PLUGIN_NAME)
+    }
+
+    fn handle_plugin_event(
+        &mut self,
+        event: NipartEvent,
+    ) -> impl std::future::Future<Output = ()> + Send {
+        async {
+            self.log(
+                NipartLogLevel::Debug,
+                event.uuid,
+                format!("Got event {event}"),
+            )
+            .await;
+            self.log(
+                NipartLogLevel::Trace,
+                event.uuid,
+                format!("Got event {event:?}"),
+            )
+            .await;
+
+            match event.plugin {
+                NipartPluginEvent::QueryPluginInfo => {
+                    let reply =
+                        Self::handle_query_plugin_info(event.uuid, &event.src);
+                    self.log(
+                        NipartLogLevel::Debug,
+                        event.uuid,
+                        format!("Sending {reply}",),
+                    )
+                    .await;
+                    self.log(
+                        NipartLogLevel::Trace,
+                        event.uuid,
+                        format!("Sending {reply:?}",),
+                    )
+                    .await;
+                    if let Err(e) = self.sender_to_daemon().send(reply).await {
+                        self.log(
+                            NipartLogLevel::Error,
+                            event.uuid,
+                            format!("{e}",),
+                        )
+                        .await;
+                    }
+                }
+                NipartPluginEvent::ChangeLogLevel(l) => {
+                    let reply = self.handle_change_log_level(l, event.uuid);
+                    self.log(
+                        NipartLogLevel::Debug,
+                        event.uuid,
+                        format!("Sending {reply}",),
+                    )
+                    .await;
+                    self.log(
+                        NipartLogLevel::Trace,
+                        event.uuid,
+                        format!("Sending {reply:?}",),
+                    )
+                    .await;
+                    if let Err(e) = self.sender_to_daemon().send(reply).await {
+                        self.log(
+                            NipartLogLevel::Error,
+                            event.uuid,
+                            format!("{e}",),
+                        )
+                        .await;
+                    }
+                }
+                NipartPluginEvent::QueryLogLevel => {
+                    let reply = Self::handle_query_log_level(event.uuid);
+                    self.log(
+                        NipartLogLevel::Debug,
+                        event.uuid,
+                        format!("Sending {reply}",),
+                    )
+                    .await;
+                    self.log(
+                        NipartLogLevel::Trace,
+                        event.uuid,
+                        format!("Sending {reply:?}",),
+                    )
+                    .await;
+                    if let Err(e) = self.sender_to_daemon().send(reply).await {
+                        self.log(
+                            NipartLogLevel::Error,
+                            event.uuid,
+                            format!("{e}",),
+                        )
+                        .await;
+                    }
+                }
+                _ => {
+                    let uuid = event.uuid;
+                    if let Err(e) = self.handle_event(event).await {
+                        self.log(NipartLogLevel::Error, uuid, format!("{e}"))
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_event(
+        &mut self,
+        event: NipartEvent,
+    ) -> impl Future<Output = Result<(), NipartError>> + Send;
+
+    fn run(&mut self) -> impl std::future::Future<Output = ()> + Send {
+        async move {
+            loop {
+                match self.recver_from_daemon().recv().await {
+                    Some(event) if event.plugin == NipartPluginEvent::Quit => {
+                        break;
+                    }
+                    Some(event) => self.handle_plugin_event(event).await,
+                    None => {
+                        self.log(
+                            NipartLogLevel::Debug,
+                            0,
+                            "MPSC channel remote end closed".to_string(),
+                        )
+                        .await;
+
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/state/ifaces/bond.rs
+++ b/src/lib/state/ifaces/bond.rs
@@ -14,7 +14,9 @@ use crate::{
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
-/// Bond interface. When serializing or deserializing, the [BaseInterface] will
+/// Bond interface.
+///
+/// When serializing or deserializing, the [BaseInterface] will
 /// be flatted and [BondConfig] stored as `link-aggregation` section. The yaml
 /// output [crate::NetworkState] containing an example bond interface:
 /// ```yml
@@ -700,13 +702,14 @@ impl From<BondAllPortsActive> for u8 {
     }
 }
 
+/// The `arp_all_targets` kernel bond option.
+///
+/// Specifies the quantity of arp_ip_targets that must be reachable in order for
+/// the ARP monitor to consider a port as being up. This option affects only
+/// active-backup mode for ports with arp_validation enabled.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case", remote = "BondArpAllTargets")]
 #[non_exhaustive]
-/// The `arp_all_targets` kernel bond option: Specifies the quantity of
-/// arp_ip_targets that must be reachable in order for the ARP monitor to
-/// consider a port as being up. This option affects only active-backup mode
-/// for ports with arp_validation enabled.
 pub enum BondArpAllTargets {
     /// consider the port up only when any of the `arp_ip_targets` is reachable
     #[serde(alias = "0")]
@@ -752,13 +755,14 @@ impl std::fmt::Display for BondArpAllTargets {
     }
 }
 
+/// The `arp_validate` kernel bond option.
+///
+/// Specifies whether or not ARP probes and replies should be validated in any
+/// mode that supports arp monitoring, or whether non-ARP traffic should be
+/// filtered (disregarded) for link monitoring purposes.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "snake_case", remote = "BondArpValidate")]
 #[non_exhaustive]
-/// The `arp_validate` kernel bond option: Specifies whether or not ARP probes
-/// and replies should be validated in any mode that supports arp monitoring, or
-/// whether non-ARP traffic should be filtered (disregarded) for link monitoring
-/// purposes.
 pub enum BondArpValidate {
     /// No validation or filtering is performed.
     /// Serialize to `none`.
@@ -839,13 +843,15 @@ impl std::fmt::Display for BondArpValidate {
     }
 }
 
+/// The `fail_over_mac` kernel bond option.
+///
+/// Specifies whether active-backup mode should set all ports to the same MAC
+/// address at port attachment (the traditional behavior), or, when enabled,
+/// perform special handling of the bond's MAC address in accordance with the
+/// selected policy.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "kebab-case", remote = "BondFailOverMac")]
 #[non_exhaustive]
-/// The `fail_over_mac` kernel bond option: Specifies whether active-backup mode
-/// should set all ports to the same MAC address at port attachment (the
-/// traditional behavior), or, when enabled, perform special handling of the
-/// bond's MAC address in accordance with the selected policy.
 pub enum BondFailOverMac {
     /// This setting disables fail_over_mac, and causes bonding to set all
     /// ports of an active-backup bond to the same MAC address at attachment
@@ -910,14 +916,15 @@ impl std::fmt::Display for BondFailOverMac {
     }
 }
 
+/// The `primary_reselect` kernel bond option.
+///
+/// Specifies the reselection policy for the primary port. This affects how the
+/// primary port is chosen to become the active port when failure of the active
+/// port or recovery of the primary port occurs. This option is designed to
+/// prevent flip-flopping between the primary port and other ports.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case", remote = "BondPrimaryReselect")]
 #[non_exhaustive]
-/// The `primary_reselect` kernel bond option: Specifies the reselection policy
-/// for the primary port. This affects how the primary port is chosen to
-/// become the active port when failure of the active port or recovery of the
-/// primary port occurs. This option is designed to prevent flip-flopping
-/// between the primary port and other ports.
 pub enum BondPrimaryReselect {
     ///The primary port becomes the active port whenever it comes back up.
     /// Serialize to `always`.
@@ -974,11 +981,13 @@ impl std::fmt::Display for BondPrimaryReselect {
     }
 }
 
+/// The `xmit_hash_policy` kernel bond option.
+///
+/// Selects the transmit hash policy to use for port selection in balance-xor,
+/// 802.3ad, and tlb modes.
 #[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Clone, Copy)]
 #[non_exhaustive]
 #[serde(remote = "BondXmitHashPolicy")]
-/// The `xmit_hash_policy` kernel bond option: Selects the transmit hash policy
-/// to use for port selection in balance-xor, 802.3ad, and tlb modes.
 pub enum BondXmitHashPolicy {
     #[serde(rename = "layer2", alias = "0")]
     /// Serialize to `layer2`.

--- a/src/lib/state/ifaces/inter_ifaces.rs
+++ b/src/lib/state/ifaces/inter_ifaces.rs
@@ -23,14 +23,14 @@ const COPY_MAC_ALLOWED_IFACE_TYPES: [InterfaceType; 3] = [
     InterfaceType::OvsInterface,
 ];
 
+/// Represent a list of [Interface].
+///
+/// With special [serde::Deserializer] and [serde::Serializer].  When applying
+/// complex nested interface(e.g. bridge over bond over vlan of eth1), the
+/// supported maximum nest level is 4 like previous example.  For 5+ nested
+/// level, you need to place controller interface before its ports.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
-/// Represent a list of [Interface] with special [serde::Deserializer] and
-/// [serde::Serializer].
-/// When applying complex nested interface(e.g. bridge over bond over vlan of
-/// eth1), the supported maximum nest level is 4 like previous example.
-/// For 5+ nested level, you need to place controller interface before its
-/// ports.
 pub struct Interfaces {
     pub kernel_ifaces: HashMap<String, Interface>,
     pub(crate) user_ifaces: HashMap<(String, InterfaceType), Interface>,

--- a/src/lib/state/ifaces/ipsec.rs
+++ b/src/lib/state/ifaces/ipsec.rs
@@ -4,12 +4,11 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::{BaseInterface, InterfaceType, NetworkState};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-/// The libreswan Ipsec interface. This interface does not exist in kernel
-/// space but only exist in user space tools.
-/// This is the example yaml output of [crate::NetworkState] with a libreswan
-/// ipsec connection:
+/// The libreswan Ipsec interface.
+///
+/// This interface does not exist in kernel space but only exist in user space
+/// tools.  This is the example yaml output of [crate::NetworkState] with a
+/// libreswan ipsec connection:
 /// ```yaml
 /// ---
 /// interfaces:
@@ -26,6 +25,8 @@ use crate::{BaseInterface, InterfaceType, NetworkState};
 ///     leftcert: hosta.example.org
 ///     ikev2: insist
 /// ```
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct IpsecInterface {
     #[serde(flatten)]
     pub base: BaseInterface,

--- a/src/lib/state/ifaces/linux_bridge.rs
+++ b/src/lib/state/ifaces/linux_bridge.rs
@@ -14,6 +14,7 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 /// Bridge interface provided by linux kernel.
+///
 /// When serializing or deserializing, the [BaseInterface] will
 /// be flatted and [LinuxBridgeConfig] stored as `bridge` section. The yaml
 /// output [crate::NetworkState] containing an example linux bridge interface:

--- a/src/lib/state/ifaces/vrf.rs
+++ b/src/lib/state/ifaces/vrf.rs
@@ -132,7 +132,7 @@ impl VrfInterface {
 #[non_exhaustive]
 #[serde(deny_unknown_fields)]
 pub struct VrfConfig {
-    #[serde(alias = "ports")]
+    #[serde(alias = "ports", skip_serializing_if = "Option::is_none")]
     /// Port list.
     /// Deserialize and serialize from/to `port`.
     /// Also deserialize from `ports`.

--- a/src/plugin_baize/plugin.rs
+++ b/src/plugin_baize/plugin.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nipart::{
-    NipartError, NipartEvent, NipartMonitorRule, NipartNativePlugin,
-    NipartPluginEvent, NipartRole,
+    NipartError, NipartEvent, NipartLogLevel, NipartMonitorRule,
+    NipartNativePlugin, NipartPluginEvent, NipartRole,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -10,6 +10,7 @@ use crate::link::BaizeLinkMonitor;
 
 #[derive(Debug)]
 pub struct NipartPluginBaize {
+    log_level: NipartLogLevel,
     to_daemon: Sender<NipartEvent>,
     from_daemon: Receiver<NipartEvent>,
     link_monitor: BaizeLinkMonitor,
@@ -18,11 +19,21 @@ pub struct NipartPluginBaize {
 impl NipartNativePlugin for NipartPluginBaize {
     const PLUGIN_NAME: &'static str = "baize";
 
+    fn get_log_level(&self) -> NipartLogLevel {
+        self.log_level
+    }
+
+    fn set_log_level(&mut self, level: NipartLogLevel) {
+        self.log_level = level;
+    }
+
     async fn init(
+        log_level: NipartLogLevel,
         to_daemon: Sender<NipartEvent>,
         from_daemon: Receiver<NipartEvent>,
     ) -> Result<Self, NipartError> {
         Ok(Self {
+            log_level,
             to_daemon: to_daemon.clone(),
             from_daemon,
             link_monitor: BaizeLinkMonitor::new(to_daemon)?,

--- a/src/plugin_mozim/plugin.rs
+++ b/src/plugin_mozim/plugin.rs
@@ -4,9 +4,9 @@ use std::collections::HashMap;
 
 use nipart::{
     NipartDhcpConfig, NipartError, NipartEvent, NipartEventAddress,
-    NipartLinkMonitorKind, NipartLinkMonitorRule, NipartMonitorEvent,
-    NipartMonitorRule, NipartNativePlugin, NipartPluginEvent, NipartRole,
-    NipartUserEvent,
+    NipartLinkMonitorKind, NipartLinkMonitorRule, NipartLogLevel,
+    NipartMonitorEvent, NipartMonitorRule, NipartNativePlugin,
+    NipartPluginEvent, NipartRole, NipartUserEvent,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -16,6 +16,7 @@ use crate::worker::MozimWorkerV4;
 
 #[derive(Debug)]
 pub struct NipartPluginMozim {
+    log_level: NipartLogLevel,
     to_daemon: Sender<NipartEvent>,
     from_daemon: Receiver<NipartEvent>,
     v4_workers: HashMap<String, MozimWorkerV4>,
@@ -24,11 +25,21 @@ pub struct NipartPluginMozim {
 impl NipartNativePlugin for NipartPluginMozim {
     const PLUGIN_NAME: &'static str = "mozim";
 
+    fn get_log_level(&self) -> NipartLogLevel {
+        self.log_level
+    }
+
+    fn set_log_level(&mut self, level: NipartLogLevel) {
+        self.log_level = level;
+    }
+
     async fn init(
+        log_level: NipartLogLevel,
         to_daemon: Sender<NipartEvent>,
         from_daemon: Receiver<NipartEvent>,
     ) -> Result<Self, NipartError> {
         Ok(Self {
+            log_level,
             to_daemon,
             from_daemon,
             v4_workers: HashMap::new(),

--- a/src/plugin_nispor/Cargo.toml
+++ b/src/plugin_nispor/Cargo.toml
@@ -10,7 +10,6 @@ rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true }
-env_logger = { workspace = true }
 log = { workspace = true }
 tokio = { workspace = true }
 nispor = { workspace = true }

--- a/src/plugin_nispor/plugin.rs
+++ b/src/plugin_nispor/plugin.rs
@@ -2,8 +2,8 @@
 
 use nipart::{
     MergedNetworkState, NipartApplyOption, NipartDhcpLease, NipartError,
-    NipartEvent, NipartEventAddress, NipartNativePlugin, NipartPluginEvent,
-    NipartRole, NipartUserEvent, DEFAULT_TIMEOUT,
+    NipartEvent, NipartEventAddress, NipartLogLevel, NipartNativePlugin,
+    NipartPluginEvent, NipartRole, NipartUserEvent, DEFAULT_TIMEOUT,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -15,6 +15,7 @@ const STATE_PRIORITY: u32 = 50;
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct NipartPluginNispor {
+    log_level: NipartLogLevel,
     to_daemon: Sender<NipartEvent>,
     from_daemon: Receiver<NipartEvent>,
 }
@@ -34,11 +35,21 @@ impl NipartNativePlugin for NipartPluginNispor {
         &self.to_daemon
     }
 
+    fn get_log_level(&self) -> NipartLogLevel {
+        self.log_level
+    }
+
+    fn set_log_level(&mut self, level: NipartLogLevel) {
+        self.log_level = level;
+    }
+
     async fn init(
+        log_level: NipartLogLevel,
         to_daemon: Sender<NipartEvent>,
         from_daemon: Receiver<NipartEvent>,
     ) -> Result<Self, NipartError> {
         Ok(Self {
+            log_level,
             to_daemon,
             from_daemon,
         })

--- a/src/plugin_sima/plugin.rs
+++ b/src/plugin_sima/plugin.rs
@@ -2,8 +2,8 @@
 
 use gix::ThreadSafeRepository;
 use nipart::{
-    NipartError, NipartEvent, NipartEventAddress, NipartNativePlugin,
-    NipartPluginEvent, NipartRole, NipartUserEvent,
+    NipartError, NipartEvent, NipartEventAddress, NipartLogLevel,
+    NipartNativePlugin, NipartPluginEvent, NipartRole, NipartUserEvent,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -11,6 +11,7 @@ use crate::repo::load_config_repo;
 
 #[derive(Debug)]
 pub struct NipartPluginSima {
+    log_level: NipartLogLevel,
     to_daemon: Sender<NipartEvent>,
     from_daemon: Receiver<NipartEvent>,
     pub(crate) config_repo: ThreadSafeRepository,
@@ -19,11 +20,21 @@ pub struct NipartPluginSima {
 impl NipartNativePlugin for NipartPluginSima {
     const PLUGIN_NAME: &'static str = "sima";
 
+    fn get_log_level(&self) -> NipartLogLevel {
+        self.log_level
+    }
+
+    fn set_log_level(&mut self, level: NipartLogLevel) {
+        self.log_level = level;
+    }
+
     async fn init(
+        log_level: NipartLogLevel,
         to_daemon: Sender<NipartEvent>,
         from_daemon: Receiver<NipartEvent>,
     ) -> Result<Self, NipartError> {
         Ok(Self {
+            log_level,
             to_daemon: to_daemon.clone(),
             from_daemon,
             config_repo: load_config_repo()?,

--- a/src/plugin_smith/plugin.rs
+++ b/src/plugin_smith/plugin.rs
@@ -5,8 +5,8 @@ use std::time::{Duration, SystemTime};
 
 use nipart::{
     ErrorKind, NipartError, NipartEvent, NipartEventAddress, NipartLockEntry,
-    NipartLockOption, NipartNativePlugin, NipartPluginEvent, NipartRole,
-    NipartUserEvent,
+    NipartLockOption, NipartLogLevel, NipartNativePlugin, NipartPluginEvent,
+    NipartRole, NipartUserEvent,
 };
 use tokio::sync::mpsc::{Receiver, Sender};
 
@@ -36,6 +36,7 @@ impl SmithLockOwner {
 
 #[derive(Debug)]
 pub struct NipartPluginSmith {
+    log_level: NipartLogLevel,
     to_daemon: Sender<NipartEvent>,
     from_daemon: Receiver<NipartEvent>,
     vault: HashMap<NipartLockEntry, SmithLockOwner>,
@@ -44,11 +45,21 @@ pub struct NipartPluginSmith {
 impl NipartNativePlugin for NipartPluginSmith {
     const PLUGIN_NAME: &'static str = "smith";
 
+    fn get_log_level(&self) -> NipartLogLevel {
+        self.log_level
+    }
+
+    fn set_log_level(&mut self, level: NipartLogLevel) {
+        self.log_level = level;
+    }
+
     async fn init(
+        log_level: NipartLogLevel,
         to_daemon: Sender<NipartEvent>,
         from_daemon: Receiver<NipartEvent>,
     ) -> Result<Self, NipartError> {
         Ok(Self {
+            log_level,
             to_daemon: to_daemon.clone(),
             from_daemon,
             vault: HashMap::new(),


### PR DESCRIPTION
when user send request to daemon, daemon also redirect plugin logs to user.

The `NipartNativePlugin:log()` is introduced allowing native plugin to
send logs to user.