### PR TITLE
Cargo: Remove std feature of log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rust-version = "1.75"
 [workspace.dependencies]
 serde = { version = "1.0.144", features = ["derive"] }
 env_logger = "0.9.0"
-log = { version = "0.4.17", features = ["std"] }
+log = "0.4.17"
 serde_json = "1.0.87"
 serde_yaml = "0.9.27"
 uuid = { version = "1.6.1", default-features = false, features = ["std", "v7"] }


### PR DESCRIPTION
We do not need the boxed logger anymore. Removing.