### PR TITLE
gen_revert: Include full current state if desire is absent

### DIFF
--- a/src/lib/state/revert/ifaces/iface.rs
+++ b/src/lib/state/revert/ifaces/iface.rs
@@ -33,6 +33,10 @@ impl Interface {
         &self,
         current: &Self,
     ) -> Result<Self, NipartError> {
+        if self.is_absent() {
+            return Ok(current.clone());
+        }
+
         let mut revert_value =
             serde_json::to_value(current.clone_name_type_only())?;
         let desired_value = serde_json::to_value(self)?;


### PR DESCRIPTION
When a desire state is marking interface as absent, its revert state
should copy full previous state.