### PR TITLE
Add support of wireguard

### DIFF
--- a/src/cli/show.rs
+++ b/src/cli/show.rs
@@ -37,6 +37,12 @@ impl CommandShow {
                     .action(clap::ArgAction::SetTrue)
                     .help("Show the daemon saved state only"),
             )
+            .arg(
+                clap::Arg::new("SHOW_SECRETS")
+                    .long("show-secrets")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Show secrets(hide by default)"),
+            )
     }
 
     pub(crate) async fn handle(
@@ -58,12 +64,16 @@ impl CommandShow {
             };
             cli.query_network_state(opt).await?
         };
-        let net_state =
+        let mut net_state =
             if let Some(ifname) = matches.get_one::<String>("IFNAME") {
                 filter_net_state(&net_state, ifname)
             } else {
                 net_state
             };
+
+        if !matches.get_flag("SHOW_SECRETS") {
+            net_state.hide_secrets();
+        }
 
         println!("{}", serde_yaml::to_string(&net_state)?);
 

--- a/src/lib/nmstate/iface.rs
+++ b/src/lib/nmstate/iface.rs
@@ -17,7 +17,7 @@ use crate::{
     InterfaceState, InterfaceType, JsonDisplayHideSecrets,
     LinuxBridgeInterface, LoopbackInterface, NipartError, NipartstateInterface,
     OvsBridgeInterface, OvsInterface, UnknownInterface, VlanInterface,
-    WifiCfgInterface, WifiPhyInterface,
+    WifiCfgInterface, WifiPhyInterface, WireguardInterface,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, JsonDisplayHideSecrets)]
@@ -45,6 +45,7 @@ pub enum Interface {
     Bond(Box<BondInterface>),
     /// Linux Bridge Interface
     LinuxBridge(Box<LinuxBridgeInterface>),
+    Wireguard(Box<WireguardInterface>),
     /// Unknown interface.
     Unknown(Box<UnknownInterface>),
 }
@@ -135,6 +136,11 @@ impl<'de> Deserialize<'de> for Interface {
                 let inner = LinuxBridgeInterface::deserialize(v)
                     .map_err(serde::de::Error::custom)?;
                 Ok(Interface::LinuxBridge(Box::new(inner)))
+            }
+            Some(InterfaceType::Wireguard) => {
+                let inner = WireguardInterface::deserialize(v)
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Interface::Wireguard(Box::new(inner)))
             }
             _ => {
                 let inner = UnknownInterface::deserialize(v)
@@ -293,6 +299,7 @@ macro_rules! gen_iface_trait_impl {
                     Self::Vlan,
                     Self::Bond,
                     Self::LinuxBridge,
+                    Self::Wireguard,
                     Self::Unknown,
                 )
             }
@@ -317,6 +324,7 @@ macro_rules! gen_iface_trait_impl_mut {
                     Self::Vlan,
                     Self::Bond,
                     Self::LinuxBridge,
+                    Self::Wireguard,
                     Self::Unknown,
                 )
             }
@@ -355,6 +363,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         )
     }
@@ -373,6 +382,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         );
     }
@@ -396,6 +406,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         )
     }
@@ -419,6 +430,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         )
     }
@@ -440,6 +452,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         )
     }
@@ -458,6 +471,7 @@ impl NipartstateInterface for Interface {
             Interface::Vlan,
             Interface::Bond,
             Interface::LinuxBridge,
+            Interface::Wireguard,
             Interface::Unknown,
         )
     }
@@ -494,6 +508,9 @@ impl From<BaseInterface> for Interface {
             InterfaceType::IpVlan => todo!(),
             InterfaceType::WifiPhy => Interface::WifiPhy(Default::default()),
             InterfaceType::WifiCfg => Interface::WifiCfg(Default::default()),
+            InterfaceType::Wireguard => {
+                Interface::Wireguard(Default::default())
+            }
             InterfaceType::Unknown(_) => Interface::Unknown(Default::default()),
         };
         *iface.base_iface_mut() = base_iface;

--- a/src/lib/nmstate/iface_type.rs
+++ b/src/lib/nmstate/iface_type.rs
@@ -93,6 +93,8 @@ pub enum InterfaceType {
     WifiPhy,
     /// Pseudo interface for WiFi Configuration
     WifiCfg,
+    /// Wireguard Interface
+    Wireguard,
     /// Interface unknown
     #[serde(untagged)]
     Unknown(String),
@@ -143,6 +145,7 @@ impl InterfaceType {
                 | InterfaceType::Vlan
                 | InterfaceType::WifiPhy
                 | InterfaceType::Bond
+                | InterfaceType::Wireguard
         )
     }
 

--- a/src/lib/nmstate/ifaces/mod.rs
+++ b/src/lib/nmstate/ifaces/mod.rs
@@ -13,6 +13,7 @@ mod ovs_iface;
 mod unknown;
 mod vlan;
 mod wifi;
+mod wireguard;
 
 pub use self::{
     base::BaseInterface,
@@ -42,5 +43,9 @@ pub use self::{
     },
     wifi::{
         WifiAuthType, WifiCfgInterface, WifiConfig, WifiPhyInterface, WifiState,
+    },
+    wireguard::{
+        WireguardConfig, WireguardInterface, WireguardIpAddress,
+        WireguardPeerConfig,
     },
 };

--- a/src/lib/nmstate/ifaces/wifi.rs
+++ b/src/lib/nmstate/ifaces/wifi.rs
@@ -422,7 +422,7 @@ impl WifiConfig {
     pub fn hide_secrets(&mut self) {
         if self.password.is_some() {
             self.password =
-                Some(crate::NetworkState::HIDE_PASSWORD_STR.to_string());
+                Some(crate::NetworkState::HIDE_SECRET_STR.to_string());
         }
     }
 
@@ -492,7 +492,7 @@ impl From<&WifiConfig> for WifiConfigHideSecrets {
         } = v.clone();
         Self {
             password: if password.is_some() {
-                Some(crate::NetworkState::HIDE_PASSWORD_STR.to_string())
+                Some(crate::NetworkState::HIDE_SECRET_STR.to_string())
             } else {
                 None
             },

--- a/src/lib/nmstate/ifaces/wireguard.rs
+++ b/src/lib/nmstate/ifaces/wireguard.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::net::{IpAddr, SocketAddr};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    BaseInterface, ErrorKind, InterfaceType, JsonDisplay,
+    JsonDisplayHideSecrets, NipartError, NipartstateInterface,
+};
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonDisplayHideSecrets,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+/// Wireguard interface
+pub struct WireguardInterface {
+    #[serde(flatten)]
+    pub base: BaseInterface,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub wireguard: Option<WireguardConfig>,
+}
+
+impl WireguardInterface {
+    pub fn new(name: String) -> Self {
+        Self {
+            base: BaseInterface {
+                name: name.to_string(),
+                iface_type: InterfaceType::Wireguard,
+                ..Default::default()
+            },
+            wireguard: None,
+        }
+    }
+}
+
+impl Default for WireguardInterface {
+    fn default() -> Self {
+        Self {
+            base: BaseInterface {
+                iface_type: InterfaceType::Wireguard,
+                ..Default::default()
+            },
+            wireguard: None,
+        }
+    }
+}
+
+impl NipartstateInterface for WireguardInterface {
+    fn base_iface(&self) -> &BaseInterface {
+        &self.base
+    }
+
+    fn base_iface_mut(&mut self) -> &mut BaseInterface {
+        &mut self.base
+    }
+
+    fn is_virtual(&self) -> bool {
+        true
+    }
+
+    fn hide_secrets_iface_specific(&mut self) {
+        if let Some(wg_cfg) = self.wireguard.as_mut() {
+            wg_cfg.hide_secrets();
+        }
+    }
+
+    fn sanitize_iface_specfic(
+        &mut self,
+        current: Option<&Self>,
+    ) -> Result<(), NipartError> {
+        if let Some(wg_conf) = self.wireguard.as_mut() {
+            wg_conf.sanitize(
+                current.and_then(|c| c.wireguard.as_ref()),
+                self.base.name.as_str(),
+            )?;
+        } else if current.is_none() {
+            return Err(NipartError::new(
+                ErrorKind::InvalidArgument,
+                format!(
+                    "Need wireguard section for creating wireguard interface \
+                     {}",
+                    self.base.name
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonDisplayHideSecrets,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardConfig {
+    /// Base64 encoded public key, query only option, ignored when apply,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    /// Base64 encoded private key, will be replaced by `<_hidden_>` in
+    /// display or debug format.
+    /// Will use current value if defined as None or `<_hidden_>`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub private_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub listen_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fwmark: Option<u32>,
+    /// If undefined, we use current value. If defined, we override existing
+    /// peers with desired list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub peers: Option<Vec<WireguardPeerConfig>>,
+}
+
+impl WireguardConfig {
+    pub fn hide_secrets(&mut self) {
+        if self.private_key.is_some() {
+            self.private_key =
+                Some(crate::NetworkState::HIDE_SECRET_STR.to_string());
+        }
+        if let Some(peers) = self.peers.as_mut() {
+            for peer in peers {
+                peer.hide_secrets();
+            }
+        }
+    }
+
+    /// * Discard query only properties
+    /// * Need WireguardConfig for creating interface
+    /// * Need `private_key` for creating interface
+    /// * Discard `private_key` if set to `HIDE_SECRET_STR`
+    /// * Need `endpoint` for each peer config
+    pub(crate) fn sanitize(
+        &mut self,
+        current: Option<&Self>,
+        iface_name: &str,
+    ) -> Result<(), NipartError> {
+        self.public_key = None;
+
+        if current.is_none() {
+            if self.private_key.is_none() {
+                return Err(NipartError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Need private key for creating wireguard interface {}",
+                        iface_name,
+                    ),
+                ));
+            }
+        } else {
+            if self.private_key.as_deref()
+                == Some(crate::NetworkState::HIDE_SECRET_STR)
+            {
+                self.private_key = None;
+            }
+        }
+
+        if let Some(peers) = self.peers.as_mut() {
+            for peer in peers {
+                if peer.endpoint.is_none() {
+                    return Err(NipartError::new(
+                        ErrorKind::InvalidArgument,
+                        format!(
+                            "Missing mandatory property `endpoint` for \
+                             configuration wireguard peer {peer} of interface \
+                             {iface_name}",
+                        ),
+                    ));
+                }
+                peer.sanitize()?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+// TODO: The more elegant way of hide secret during debug is using Derive like
+// `#[serde(skip)]`. But that is way too complex without using deprecated quote
+// crate. Let's do the silly non-rust-idiom way for now.
+impl std::fmt::Debug for WireguardConfig {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        f.debug_struct("WireguardConfig")
+            .field("public_key", &self.public_key)
+            .field(
+                "private_key",
+                if self.private_key.is_some() {
+                    &Some(crate::NetworkState::HIDE_SECRET_STR)
+                } else {
+                    &None::<&str>
+                },
+            )
+            .field("listen_port", &self.listen_port)
+            .field("fwmark", &self.fwmark)
+            .field("peers", &self.peers)
+            .finish()
+    }
+}
+
+#[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Default,
+    Serialize,
+    Deserialize,
+    JsonDisplayHideSecrets,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+#[non_exhaustive]
+pub struct WireguardPeerConfig {
+    /// Mandatory property for apply
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub endpoint: Option<SocketAddr>,
+    /// Base64 encoded public key
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub public_key: Option<String>,
+    /// Base64 encoded preshared key, will be shown as `<_hidden_>` for Debug
+    /// and excluded from Serialize.
+    /// If undefined or defined as `<_hidden_>`, will use current value.
+    #[serde(skip_serializing)]
+    pub preshared_key: Option<String>,
+    /// Last handshake in a format of `32 seconds ago`.
+    /// Query only property, will be ignore during apply.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_handshake: Option<String>,
+    /// Query only property for received bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rx_bytes: Option<u64>,
+    /// Query only property for transmitted bytes
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tx_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub persistent_keepalive: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_ips: Option<Vec<WireguardIpAddress>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+}
+
+impl WireguardPeerConfig {
+    pub fn hide_secrets(&mut self) {
+        if self.preshared_key.is_some() {
+            self.preshared_key =
+                Some(crate::NetworkState::HIDE_SECRET_STR.to_string());
+        }
+    }
+
+    /// * Discard query only properties
+    /// * Discard `preshared_key` if set to `HIDE_SECRET_STR`
+    pub(crate) fn sanitize(&mut self) -> Result<(), NipartError> {
+        self.rx_bytes = None;
+        self.tx_bytes = None;
+        self.last_handshake = None;
+
+        if self.preshared_key.as_deref()
+            == Some(crate::NetworkState::HIDE_SECRET_STR)
+        {
+            self.preshared_key = None;
+        }
+
+        Ok(())
+    }
+}
+
+// TODO: The more elegant way of hide secret during debug is using Derive like
+// `#[serde(skip)]`. But that is way too complex without using deprecated quote
+// crate. Let's do the silly non-rust-idiom way for now.
+impl std::fmt::Debug for WireguardPeerConfig {
+    fn fmt(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+    ) -> Result<(), std::fmt::Error> {
+        f.debug_struct("WireguardPeerConf")
+            .field("endpoint", &self.endpoint)
+            .field("public_key", &self.public_key)
+            .field(
+                "preshared_key",
+                &self
+                    .preshared_key
+                    .as_ref()
+                    .map(|_| crate::NetworkState::HIDE_SECRET_STR),
+            )
+            .field("last_handshake", &self.last_handshake)
+            .field("rx_bytes", &self.rx_bytes)
+            .field("tx_bytes", &self.tx_bytes)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .field("allowed_ips", &self.allowed_ips)
+            .field("protocol_version", &self.protocol_version)
+            .finish()
+    }
+}
+
+#[derive(
+    Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Copy, JsonDisplay,
+)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct WireguardIpAddress {
+    pub ip: IpAddr,
+    pub prefix_length: u8,
+}

--- a/src/lib/nmstate/mod.rs
+++ b/src/lib/nmstate/mod.rs
@@ -39,6 +39,8 @@ pub use self::{
         UnknownInterface, VethConfig, VlanConfig, VlanInterface, VlanProtocol,
         VlanQosMapping, VlanRegistrationProtocol, WifiAuthType,
         WifiCfgInterface, WifiConfig, WifiPhyInterface, WifiState,
+        WireguardConfig, WireguardInterface, WireguardIpAddress,
+        WireguardPeerConfig,
     },
     ip::{DhcpState, InterfaceIpAddr, InterfaceIpv4, InterfaceIpv6},
     merged::{

--- a/src/lib/nmstate/net_state.rs
+++ b/src/lib/nmstate/net_state.rs
@@ -39,9 +39,10 @@ impl Default for NetworkState {
 }
 
 impl NetworkState {
-    pub const HIDE_PASSWORD_STR: &str = "<_password_hidden_by_nmstate>";
-    /// Nipartstate cannot retrieve password
-    pub const UNKNOWN_PASSWRD_STR: &str = "<_password_unknown_to_nmstate>";
+    /// Secret hidden by nipart
+    pub const HIDE_SECRET_STR: &str = "<_hidden_>";
+    /// Nipart cannot retrieve secret
+    pub const UNKNOWN_SECRET_STR: &str = "<_unknown_>";
 
     /// Return a network state with secrets only leaving self without any
     /// secrets.

--- a/src/lib/nmstate/revert/value.rs
+++ b/src/lib/nmstate/revert/value.rs
@@ -25,7 +25,7 @@ pub(crate) fn gen_revert_state(
             };
             for (key, des_value) in des_obj.iter() {
                 let des_value_display = if SECRET_KEYS.contains(&key.as_str()) {
-                    &Value::from(crate::NetworkState::HIDE_PASSWORD_STR)
+                    &Value::from(crate::NetworkState::HIDE_SECRET_STR)
                 } else {
                     des_value
                 };

--- a/src/lib/nmstate/value.rs
+++ b/src/lib/nmstate/value.rs
@@ -43,7 +43,7 @@ fn _get_json_value_difference<'a, 'b>(
         }
         (Value::String(des), Value::String(cur)) => {
             if des != cur {
-                if des == crate::NetworkState::HIDE_PASSWORD_STR {
+                if des == crate::NetworkState::HIDE_SECRET_STR {
                     None
                 } else {
                     Some((reference, desire, current))

--- a/src/lib/no_daemon/base_iface.rs
+++ b/src/lib/no_daemon/base_iface.rs
@@ -32,6 +32,7 @@ fn np_iface_type_to_nmstate(
         nispor::IfaceType::Xfrm => InterfaceType::Xfrm,
         nispor::IfaceType::IpVlan => InterfaceType::IpVlan,
         nispor::IfaceType::Wifi => InterfaceType::WifiPhy,
+        nispor::IfaceType::Wireguard => InterfaceType::Wireguard,
         nispor::IfaceType::Other(v) => InterfaceType::Unknown(v.to_lowercase()),
         _ => {
             InterfaceType::Unknown(format!("{np_iface_type:?}").to_lowercase())

--- a/src/lib/no_daemon/iface.rs
+++ b/src/lib/no_daemon/iface.rs
@@ -3,7 +3,7 @@
 use super::{
     base_iface::apply_base_iface_link_changes, bond::apply_bond_conf,
     ethernet::apply_ethernet_conf, linux_bridge::apply_bridge_conf,
-    vlan::apply_vlan_conf,
+    vlan::apply_vlan_conf, wireguard::apply_wg_conf,
 };
 use crate::{
     BaseInterface, Interface, InterfaceState, InterfaceType, MergedInterfaces,
@@ -22,6 +22,7 @@ pub(crate) fn nmstate_iface_type_to_nispor(
         InterfaceType::Vlan => nispor::IfaceType::Vlan,
         InterfaceType::Bond => nispor::IfaceType::Bond,
         InterfaceType::LinuxBridge => nispor::IfaceType::Bridge,
+        InterfaceType::Wireguard => nispor::IfaceType::Wireguard,
         v => {
             log::warn!(
                 "BUG: Requesting unsupported interface type {iface_type}"
@@ -93,6 +94,8 @@ pub(crate) fn apply_iface_link_changes(
                 None
             },
         )
+    } else if let Interface::Wireguard(apply_iface) = apply_iface {
+        apply_wg_conf(np_iface, apply_iface)
     } else {
         Ok(vec![np_iface])
     }

--- a/src/lib/no_daemon/mod.rs
+++ b/src/lib/no_daemon/mod.rs
@@ -16,6 +16,7 @@ mod route;
 mod vlan;
 mod watcher;
 mod wifi;
+mod wireguard;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct NipartNoDaemon {}

--- a/src/lib/no_daemon/query.rs
+++ b/src/lib/no_daemon/query.rs
@@ -8,7 +8,7 @@ use crate::{
     BondInterface, DummyInterface, ErrorKind, EthernetInterface, Interface,
     InterfaceType, LinuxBridgeInterface, LoopbackInterface, NetworkState,
     NipartError, NipartNoDaemon, NipartstateInterface, NipartstateQueryOption,
-    UnknownInterface, VlanInterface, WifiPhyInterface,
+    UnknownInterface, VlanInterface, WifiPhyInterface, WireguardInterface,
 };
 
 impl NipartNoDaemon {
@@ -103,6 +103,12 @@ impl NipartNoDaemon {
                     }
                     br_iface.append_br_port_config(np_iface, port_np_ifaces);
                     Interface::LinuxBridge(Box::new(br_iface))
+                }
+                InterfaceType::Wireguard => {
+                    let wg_iface = WireguardInterface::new_from_nispor(
+                        base_iface, np_iface,
+                    );
+                    Interface::Wireguard(Box::new(wg_iface))
                 }
                 _ => {
                     log::trace!(

--- a/src/lib/no_daemon/wifi/query.rs
+++ b/src/lib/no_daemon/wifi/query.rs
@@ -42,7 +42,7 @@ impl NipartWpaConn {
                     })
                 {
                     wifi_cfg.password = Some(
-                        crate::NetworkState::UNKNOWN_PASSWRD_STR.to_string(),
+                        crate::NetworkState::UNKNOWN_SECRET_STR.to_string(),
                     );
                 }
                 wifi_cfg.state = Some(wpa_iface.state.into());

--- a/src/lib/no_daemon/wireguard.rs
+++ b/src/lib/no_daemon/wireguard.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    BaseInterface, NipartError, WireguardConfig, WireguardInterface,
+    WireguardIpAddress, WireguardPeerConfig,
+};
+
+impl From<&nispor::WireguardInfo> for WireguardConfig {
+    fn from(np_wg: &nispor::WireguardInfo) -> Self {
+        WireguardConfig {
+            public_key: np_wg.public_key.clone(),
+            private_key: np_wg.private_key.clone(),
+            listen_port: np_wg.listen_port,
+            fwmark: np_wg.fwmark,
+            peers: np_wg.peers.as_ref().map(|np_peers| {
+                np_peers.iter().map(|np_peer| np_peer.into()).collect()
+            }),
+        }
+    }
+}
+
+impl From<&WireguardConfig> for nispor::WireguardConf {
+    fn from(v: &WireguardConfig) -> Self {
+        let mut np_wg = Self::default();
+        np_wg.private_key = v.private_key.clone();
+        np_wg.listen_port = v.listen_port;
+        np_wg.fwmark = v.fwmark;
+        np_wg.peers = v
+            .peers
+            .as_ref()
+            .map(|peers| peers.iter().map(|peer| peer.into()).collect());
+        np_wg
+    }
+}
+
+impl From<&nispor::WireguardPeerInfo> for WireguardPeerConfig {
+    fn from(np_wg: &nispor::WireguardPeerInfo) -> Self {
+        Self {
+            endpoint: np_wg.endpoint,
+            public_key: np_wg.public_key.clone(),
+            preshared_key: np_wg.preshared_key.clone(),
+            last_handshake: np_wg.last_handshake.clone(),
+            rx_bytes: np_wg.rx_bytes,
+            tx_bytes: np_wg.tx_bytes,
+            persistent_keepalive: np_wg.persistent_keepalive,
+            allowed_ips: np_wg.allowed_ips.as_ref().map(|np_ips| {
+                np_ips.iter().map(|np_ip| np_ip.into()).collect()
+            }),
+            protocol_version: np_wg.protocol_version,
+        }
+    }
+}
+
+impl From<&WireguardPeerConfig> for nispor::WireguardPeerConf {
+    fn from(v: &WireguardPeerConfig) -> Self {
+        let mut np_wg = Self::default();
+        np_wg.endpoint = v.endpoint;
+        np_wg.public_key = v.public_key.clone();
+        np_wg.preshared_key = v.preshared_key.clone();
+        np_wg.persistent_keepalive = v.persistent_keepalive;
+        np_wg.allowed_ips = v
+            .allowed_ips
+            .as_ref()
+            .map(|ips| ips.iter().map(|ip| ip.into()).collect());
+        np_wg
+    }
+}
+
+impl From<&nispor::WireguardIpAddress> for WireguardIpAddress {
+    fn from(np_wg: &nispor::WireguardIpAddress) -> Self {
+        Self {
+            ip: np_wg.address,
+            prefix_length: np_wg.prefix_length,
+        }
+    }
+}
+
+impl From<&WireguardIpAddress> for nispor::WireguardIpAddress {
+    fn from(v: &WireguardIpAddress) -> Self {
+        Self {
+            address: v.ip,
+            prefix_length: v.prefix_length,
+        }
+    }
+}
+
+pub(crate) fn apply_wg_conf(
+    mut np_iface: nispor::IfaceConf,
+    iface: &WireguardInterface,
+) -> Result<Vec<nispor::IfaceConf>, NipartError> {
+    if let Some(wg_conf) = iface.wireguard.as_ref() {
+        np_iface.wireguard = Some(wg_conf.into());
+    }
+    Ok(vec![np_iface])
+}
+
+impl WireguardInterface {
+    pub(crate) fn new_from_nispor(
+        base_iface: BaseInterface,
+        np_iface: &nispor::Iface,
+    ) -> Self {
+        if let Some(np_wg_conf) = np_iface.wireguard.as_ref() {
+            Self {
+                base: base_iface,
+                wireguard: Some(np_wg_conf.into()),
+            }
+        } else {
+            Self {
+                base: base_iface,
+                ..Default::default()
+            }
+        }
+    }
+}

--- a/tests/wg_test.py
+++ b/tests/wg_test.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+import nipart
+
+from .testlib.cmdlib import exec_cmd
+from .testlib.dhcp import DHCP_SRV_IP4
+from .testlib.dhcp import DHCP_SRV_IP4_PREFIX
+from .testlib.env import is_fedora
+from .testlib.retry import retry_till_true_or_timeout
+from .testlib.statelib import load_yaml
+
+
+WG_TEST_NIC = "wg0"
+
+
+@pytest.fixture
+def clean_up():
+    yield
+    nipart.apply(
+        load_yaml(
+            f"""---
+            interfaces:
+              - name: {WG_TEST_NIC}
+                type: wireguard
+                state: absent"""
+        )
+    )
+
+
+def test_wireguard_iface_static_ip(clean_up):
+    desired_state = load_yaml(
+        f"""---
+        interfaces:
+          - name: {WG_TEST_NIC}
+            type: wireguard
+            state: up
+            wireguard:
+              public-key: "JKossUAjywXuJ2YVcaeD6PaHs+afPmIthDuqEVlspwA="
+              private-key: "6LTHiAM4vgKEgi5vm30f/EBIEWFDmySkTc9EWCcIqEs="
+              listen-port: 51820
+              peers:
+                - endpoint: 192.0.2.0:51820
+                  public-key: 8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk=
+                  preshared-key: TqIkTsTSxWJ1vSnhUW2oXFAtB5l9hRFWdgn2BrKX3ik=
+                  persistent-keepalive: 0
+                  allowed-ips:
+                  - ip: 0.0.0.0
+                    prefix-length: 0
+                  - ip: '::'
+                    prefix-length: 0
+                  protocol-version: 1
+        """
+    )
+    nipart.apply(desired_state)


### PR DESCRIPTION
Example YAML:

```yml
interfaces:
- name: wg0
  type: wireguard
  state: up
  wireguard:
    public-key: "JKossUAjywXuJ2YVcaeD6PaHs+afPmIthDuqEVlspwA="
    private-key: "6LTHiAM4vgKEgi5vm30f/EBIEWFDmySkTc9EWCcIqEs="
    listen-port: 51820
    peers:
      - endpoint: 192.0.2.0:51820
        public-key: 8bdQrVLqiw3ZoHCucNh1YfH0iCWuyStniRr8t7H24Fk=
        preshared-key: TqIkTsTSxWJ1vSnhUW2oXFAtB5l9hRFWdgn2BrKX3ik=
        persistent-keepalive: 0
        allowed-ips:
        - ip: 0.0.0.0
          prefix-length: 0
        - ip: '::'
          prefix-length: 0
        protocol-version: 1
```

Integration test case included.