### PR TITLE
test: Enable WIFI test on OS with mac80211_hwsim kernel module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,10 +23,11 @@ jobs:
         run: |
           rustup override set stable
           rustup update stable
-      - name: Install pytest
+
+      - name: Install tools required for tests
         run: |
           sudo apt update
-          sudo apt -y install python3-pytest
+          sudo apt -y install python3-pytest dnsmasq
 
       - name: Unit Test
         run: cargo test
@@ -36,4 +37,3 @@ jobs:
 
       - name: Integration test
         run: sudo tests/run-tests.sh
-

--- a/tests/testlib/env.py
+++ b/tests/testlib/env.py
@@ -2,12 +2,17 @@
 
 import os
 import pathlib
-
-
-def is_fedora():
-    return os.path.exists("/etc/fedora-release")
+from .cmdlib import exec_cmd
 
 
 def npt_path():
     project_dir = pathlib.Path(__file__).parent.parent.parent.resolve()
     return f"{project_dir}/target/debug/npt"
+
+
+def has_kernel_module(name):
+    try:
+        exec_cmd(f"modprobe {name} -n".split())
+        return True
+    except Exception:
+        return False

--- a/tests/wg_test.py
+++ b/tests/wg_test.py
@@ -7,7 +7,6 @@ import nipart
 from .testlib.cmdlib import exec_cmd
 from .testlib.dhcp import DHCP_SRV_IP4
 from .testlib.dhcp import DHCP_SRV_IP4_PREFIX
-from .testlib.env import is_fedora
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import load_yaml
 

--- a/tests/wifi_test.py
+++ b/tests/wifi_test.py
@@ -7,13 +7,13 @@ import nipart
 from .testlib.cmdlib import exec_cmd
 from .testlib.dhcp import DHCP_SRV_IP4
 from .testlib.dhcp import DHCP_SRV_IP4_PREFIX
-from .testlib.env import is_fedora
+from .testlib.env import has_kernel_module
 from .testlib.retry import retry_till_true_or_timeout
 from .testlib.statelib import load_yaml
 from .testlib.wifi import TEST_WIFI_PSK
 from .testlib.wifi import TEST_WIFI_SSID
 from .testlib.wifi import WIFI_TEST_NIC
-from .testlib.wifi import wifi_env
+from .testlib.wifi import wifi_env  # noqa: F401
 
 
 @pytest.fixture
@@ -29,16 +29,17 @@ def clean_up():
 def ping_peer():
     try:
         exec_cmd(f"ping {DHCP_SRV_IP4} -c 1 -w 5".split())
-    except:
+    except Exception:
         return False
     return True
 
 
 @pytest.mark.skipif(
-    not is_fedora(), reason=("Only fedora has mac80211_hwsim module ")
+    not has_kernel_module("mac80211_hwsim"),
+    reason=("Does not have 'mac80211_hwsim' module "),
 )
 class TestWifi:
-    def test_wifi_iface_static_ip(self, clean_up, wifi_env):
+    def test_wifi_iface_static_ip(self, clean_up, wifi_env):  # noqa: F811
         nipart.apply(load_yaml(f"""---
                 interfaces:
                   - name: {WIFI_TEST_NIC}
@@ -55,7 +56,7 @@ class TestWifi:
                           prefix-length: 24"""))
         assert retry_till_true_or_timeout(5, ping_peer)
 
-    def test_wifi_iface_dhcpv4(self, wifi_env, clean_up):
+    def test_wifi_iface_dhcpv4(self, clean_up, wifi_env):  # noqa: F811
         nipart.apply(load_yaml(f"""---
                 interfaces:
                   - name: {WIFI_TEST_NIC}


### PR DESCRIPTION
Any OS with `mac80211_hwsim` will run WIFI test.

Unfortunately, github CI is using azure kernel which does not ship this
`mac80211_hwsim` kernel module at any azure kernel sub-packages.

We may use nested virtualization to test this in the future.