### PR TITLE
Introducing `npt wait-online` support

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,4 +13,3 @@
  * Plugin cannot send back logs to user
  * WIFI should connect to AP with best signal
  * `nmc wifi connect` should wait connect and retry for wrong-password
- * `npt wait-online` for systemd service `Before=network-online.target`

--- a/packaging/nipart-wait-online.service
+++ b/packaging/nipart-wait-online.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Wait nipart daemon to setup network and reach online state
+#Documentation=man:npt(8)
+After=nipart.service
+Requires=nipart.service
+Before=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/npt wait-online
+RemainAfterExit=yes
+
+[Install]
+WantedBy=network-online.target

--- a/src/cli/error.rs
+++ b/src/cli/error.rs
@@ -2,8 +2,9 @@
 
 use nipart::NipartError;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct CliError {
+    pub(crate) nipart_error: Option<NipartError>,
     msg: String,
 }
 
@@ -23,6 +24,7 @@ impl From<serde_yaml::Error> for CliError {
     fn from(e: serde_yaml::Error) -> Self {
         Self {
             msg: format!("serde_yaml::Error: {}", e),
+            ..Default::default()
         }
     }
 }
@@ -31,14 +33,17 @@ impl From<std::io::Error> for CliError {
     fn from(e: std::io::Error) -> Self {
         Self {
             msg: format!("std::io::Error: {}", e),
+            ..Default::default()
         }
     }
 }
 
 impl From<NipartError> for CliError {
     fn from(e: NipartError) -> Self {
+        let msg = format!("NipartError: {}: {}", e.kind, e.msg);
         Self {
-            msg: format!("NipartError: {}: {}", e.kind, e.msg),
+            nipart_error: Some(e),
+            msg,
         }
     }
 }
@@ -47,12 +52,16 @@ impl From<&str> for CliError {
     fn from(msg: &str) -> Self {
         Self {
             msg: msg.to_string(),
+            ..Default::default()
         }
     }
 }
 
 impl From<String> for CliError {
     fn from(msg: String) -> Self {
-        Self { msg }
+        Self {
+            msg,
+            ..Default::default()
+        }
     }
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -6,15 +6,20 @@ mod error;
 mod merge;
 mod show;
 mod state;
+mod wait_online;
 mod wifi;
 
-use nipart::NipartClient;
+use nipart::{ErrorKind, NipartClient};
 
 pub(crate) use self::error::CliError;
 use self::{
     apply::CommandApply, diff::CommandDiff, merge::CommandMerge,
-    show::CommandShow, wifi::CommandWifi,
+    show::CommandShow, wait_online::CommandWaitOnline, wifi::CommandWifi,
 };
+
+const RC_FAIL: i32 = 1;
+// The error code used by /usr/bin/timeout
+const RC_TIMEOUT: i32 = 124;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), CliError> {
@@ -41,6 +46,7 @@ async fn main() -> Result<(), CliError> {
         .subcommand(CommandApply::new_cmd())
         .subcommand(CommandWifi::new_cmd())
         .subcommand(CommandDiff::new_cmd())
+        .subcommand(CommandWaitOnline::new_cmd())
         .subcommand(CommandMerge::new_cmd());
 
     let matches = cli_cmd.get_matches_mut();
@@ -69,7 +75,11 @@ async fn main() -> Result<(), CliError> {
 
     if let Err(e) = call_subcommand(&matches).await {
         eprintln!("{e}");
-        std::process::exit(1);
+        if e.nipart_error.as_ref().map(|e| e.kind) == Some(ErrorKind::Timeout) {
+            std::process::exit(RC_TIMEOUT);
+        } else {
+            std::process::exit(RC_FAIL);
+        }
     }
 
     Ok(())
@@ -96,6 +106,9 @@ async fn call_subcommand(matches: &clap::ArgMatches) -> Result<(), CliError> {
         Ok(())
     } else if let Some(matches) = matches.subcommand_matches(CommandDiff::CMD) {
         CommandDiff::handle(matches).await?;
+        Ok(())
+    } else if matches.subcommand_matches(CommandWaitOnline::CMD).is_some() {
+        CommandWaitOnline::handle().await?;
         Ok(())
     } else {
         Err(CliError::from("Unknown command"))

--- a/src/cli/wait_online.rs
+++ b/src/cli/wait_online.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nipart::NipartClient;
+
+use crate::CliError;
+
+pub(crate) struct CommandWaitOnline;
+
+impl CommandWaitOnline {
+    pub(crate) const CMD: &str = "wait-online";
+
+    pub(crate) fn new_cmd() -> clap::Command {
+        clap::Command::new(Self::CMD)
+            .alias("w")
+            .about("Wait daemon to reach online state")
+    }
+
+    pub(crate) async fn handle() -> Result<(), CliError> {
+        let mut cli = NipartClient::new().await?;
+        cli.wait_online().await?;
+        println!("Network is online");
+        Ok(())
+    }
+}

--- a/src/daemon/api.rs
+++ b/src/daemon/api.rs
@@ -82,6 +82,10 @@ pub(crate) async fn process_api_connection(
                 drop(lock);
                 conn.send(result).await?;
             }
+            NipartClientCmd::WaitOnline => {
+                let result = commander.wait_online().await;
+                conn.send(result).await?;
+            }
             _ => {
                 conn.send::<Result<NetworkState, NipartError>>(Err(
                     NipartError::new(
@@ -109,7 +113,7 @@ fn get_peer_info(
     .map_err(|e| {
         NipartError::new(
             ErrorKind::Bug,
-            format!("Failed to getsockopt SO_PEERCRED failed: {e}"),
+            format!("Failed to getsockopt SO_PEERCRED: {e}"),
         )
     })?;
 
@@ -124,7 +128,7 @@ fn permission_check(
         Ok(())
     } else {
         match command {
-            NipartClientCmd::Ping => Ok(()),
+            NipartClientCmd::Ping | NipartClientCmd::WaitOnline => Ok(()),
             NipartClientCmd::QueryNetworkState(s) => {
                 if s.include_secrets {
                     Err(NipartError::new(

--- a/src/daemon/apply.rs
+++ b/src/daemon/apply.rs
@@ -151,6 +151,8 @@ impl NipartCommander {
         };
         diff_state.hide_secrets();
 
+        self.try_set_daemon_online(Some(&saved_state), None).await?;
+
         Ok(diff_state)
     }
 
@@ -232,6 +234,8 @@ impl NipartCommander {
         )
         .await;
         merged_state.verify(&post_apply_current_state)?;
+        self.try_set_daemon_online(None, Some(&post_apply_current_state))
+            .await?;
         Ok(())
     }
 

--- a/src/daemon/daemon.rs
+++ b/src/daemon/daemon.rs
@@ -8,11 +8,14 @@ use nipart::{
     ErrorKind, NipartClient, NipartError, NipartIpcConnection,
     NipartIpcListener,
 };
+use tokio::sync::SetOnce;
 
 use super::{
     api::process_api_connection, commander::NipartCommander,
     link_event::NipartLinkEvent,
 };
+
+pub(crate) static DAEMON_IS_ONLINE: SetOnce<()> = SetOnce::const_new();
 
 #[derive(Debug, Clone)]
 pub(crate) enum NipartManagerCmd {

--- a/src/daemon/main.rs
+++ b/src/daemon/main.rs
@@ -15,6 +15,7 @@ mod plugin;
 mod query;
 mod task;
 mod udev;
+mod wait_online;
 
 pub(crate) use self::{
     logger::{log_debug, log_error, log_info, log_trace, log_warn},

--- a/src/daemon/wait_online.rs
+++ b/src/daemon/wait_online.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nipart::{
+    ErrorKind, NetworkState, NipartError, NipartNoDaemon, NipartQueryOption,
+};
+
+use super::{commander::NipartCommander, daemon::DAEMON_IS_ONLINE};
+
+const MAX_RETRY_WAIT: u64 = 32;
+
+impl NipartCommander {
+    pub(crate) async fn try_set_daemon_online(
+        &mut self,
+        saved_state: Option<&NetworkState>,
+        cur_state: Option<&NetworkState>,
+    ) -> Result<(), NipartError> {
+        if DAEMON_IS_ONLINE.initialized() {
+            return Ok(());
+        }
+        let saved_state = if let Some(s) = saved_state {
+            s.clone()
+        } else {
+            self.conf_manager.query_state().await?
+        };
+        let online_cfg = saved_state.wait_online.unwrap_or_default();
+        if online_cfg.conditions.is_empty() {
+            // Ignore Err because it only fails when already set which is
+            // OK for us to move on.
+            DAEMON_IS_ONLINE.set(()).ok();
+            return Ok(());
+        }
+
+        let cur_state = if let Some(c) = cur_state {
+            c.clone()
+        } else {
+            NipartNoDaemon::query_network_state(NipartQueryOption::running())
+                .await?
+        };
+
+        if online_cfg
+            .conditions
+            .into_iter()
+            .all(|condition| condition.is_met(&cur_state))
+        {
+            DAEMON_IS_ONLINE.set(()).ok();
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn wait_online(&mut self) -> Result<(), NipartError> {
+        let saved_state = self.conf_manager.query_state().await?;
+        let timeout_sec = saved_state
+            .wait_online
+            .clone()
+            .unwrap_or_default()
+            .timeout_sec;
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_sec.into()),
+            self._wait_online(Some(&saved_state)),
+        )
+        .await
+        {
+            Err(_) => Err(NipartError::new(
+                ErrorKind::Timeout,
+                "Timeout on waiting daemon to reach online state".to_string(),
+            )),
+            Ok(result) => result,
+        }
+    }
+
+    async fn _wait_online(
+        &mut self,
+        saved_state: Option<&NetworkState>,
+    ) -> Result<(), NipartError> {
+        let mut retry_count = 0;
+        // We retry with interval 1 seconds for first 5 seconds for quick boot
+        // support, afterwards we wait with exponential increasing time with
+        // max 32 seconds.
+        while !DAEMON_IS_ONLINE.initialized() {
+            self.try_set_daemon_online(saved_state, None).await?;
+            let retry_wait = if retry_count > 5 {
+                2u64.pow(retry_count - 5).clamp(1, MAX_RETRY_WAIT)
+            } else {
+                1
+            };
+            tokio::time::sleep(std::time::Duration::from_secs(retry_wait))
+                .await;
+            retry_count += 1;
+        }
+        Ok(())
+    }
+}

--- a/src/lib/client.rs
+++ b/src/lib/client.rs
@@ -27,6 +27,7 @@ pub enum NipartClientCmd {
     Ping,
     QueryNetworkState(Box<NipartQueryOption>),
     ApplyNetworkState(Box<(NetworkState, NipartApplyOption)>),
+    WaitOnline,
 }
 
 impl NipartCanIpc for NipartClientCmd {
@@ -35,6 +36,7 @@ impl NipartCanIpc for NipartClientCmd {
             Self::Ping => "ping".to_string(),
             Self::QueryNetworkState(_) => "query-network-state".to_string(),
             Self::ApplyNetworkState(_) => "apply-network-state".to_string(),
+            Self::WaitOnline => "wait-online".to_string(),
         }
     }
 }
@@ -94,5 +96,10 @@ impl NipartClient {
             )))))
             .await?;
         self.ipc.recv::<NetworkState>().await
+    }
+
+    pub async fn wait_online(&mut self) -> Result<(), NipartError> {
+        self.ipc.send(Ok(NipartClientCmd::WaitOnline)).await?;
+        self.ipc.recv::<()>().await
     }
 }

--- a/src/lib/schema/merged/net_state.rs
+++ b/src/lib/schema/merged/net_state.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     InterfaceType, JsonDisplayHideSecrets, MergedInterfaces, MergedRoutes,
     NetworkState, NipartApplyOption, NipartError, NipartInterface,
+    NipartWaitOnline,
 };
 
 #[derive(
@@ -22,7 +23,9 @@ pub struct MergedNetworkState {
     pub description: Option<String>,
     pub ifaces: MergedInterfaces,
     pub routes: MergedRoutes,
+    pub wait_online: NipartWaitOnline,
     pub option: NipartApplyOption,
+    pub desired: NetworkState,
 }
 
 impl MergedNetworkState {
@@ -31,6 +34,7 @@ impl MergedNetworkState {
         current: NetworkState,
         option: NipartApplyOption,
     ) -> Result<Self, NipartError> {
+        let desired_clone = desired.clone();
         let merged_ifaces =
             MergedInterfaces::new(desired.ifaces, current.ifaces)?;
         let merged_routes =
@@ -41,7 +45,12 @@ impl MergedNetworkState {
             description: desired.description.clone(),
             ifaces: merged_ifaces,
             routes: merged_routes,
+            wait_online: desired
+                .wait_online
+                .or(current.wait_online)
+                .unwrap_or_default(),
             option,
+            desired: desired_clone,
         })
     }
 
@@ -53,6 +62,7 @@ impl MergedNetworkState {
         NetworkState {
             ifaces: self.ifaces.gen_state_for_apply(),
             routes: self.routes.gen_state_for_apply(),
+            wait_online: self.desired.wait_online.clone(),
             version: self.version,
             description: self.description.clone(),
         }
@@ -113,6 +123,10 @@ impl NetworkState {
                 .or_else(|| self.description.clone()),
             ifaces: self.ifaces.merge(&new_state.ifaces)?,
             routes: self.routes.merge(&new_state.routes)?,
+            wait_online: new_state
+                .wait_online
+                .clone()
+                .or(self.wait_online.clone()),
         };
         Ok(())
     }

--- a/src/lib/schema/mod.rs
+++ b/src/lib/schema/mod.rs
@@ -16,6 +16,7 @@ mod state_options;
 mod trigger;
 mod value;
 mod version;
+mod wait_online;
 
 #[allow(dead_code)]
 pub(crate) mod deserializer;
@@ -54,6 +55,7 @@ pub use self::{
     state_options::{NipartApplyOption, NipartQueryOption, NipartStateKind},
     trigger::InterfaceTrigger,
     version::CUR_SCHEMA_VERSION,
+    wait_online::{NipartWaitOnline, NipartWaitOnlineCondition},
 };
 
 #[cfg(test)]

--- a/src/lib/schema/net_state.rs
+++ b/src/lib/schema/net_state.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     CUR_SCHEMA_VERSION, ErrorKind, Interfaces, JsonDisplayHideSecrets,
-    NipartError, Routes,
+    NipartError, NipartWaitOnline, Routes,
 };
 
 #[derive(
@@ -19,6 +19,11 @@ pub struct NetworkState {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     /// Description for the whole desire state.
     pub description: Option<String>,
+    /// Daemon wait-online configuration, if undefined, wait IPv4 or IPv6
+    /// gateway been set or previous saved configuration. If defined, override
+    /// previous saved configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_online: Option<NipartWaitOnline>,
     /// Routes
     #[serde(default)]
     pub routes: Routes,
@@ -32,6 +37,7 @@ impl Default for NetworkState {
         Self {
             version: Some(CUR_SCHEMA_VERSION),
             description: None,
+            wait_online: None,
             ifaces: Default::default(),
             routes: Default::default(),
         }
@@ -56,13 +62,16 @@ impl NetworkState {
         self == &Self {
             version: self.version,
             ..Default::default()
-        } || (self.ifaces.is_empty() && self.routes.is_empty())
+        } || (self.ifaces.is_empty()
+            && self.routes.is_empty()
+            && self.wait_online.is_none())
     }
 
     pub fn new() -> Self {
         Self::default()
     }
 
+    // TODO(Gris): Use `rmsd-yml` to show error location in YAML.
     /// Wrapping function of [serde_yaml::from_str()] with error mapped to
     /// [NipartError].
     pub fn new_from_yaml(net_state_yaml: &str) -> Result<Self, NipartError> {

--- a/src/lib/schema/wait_online.rs
+++ b/src/lib/schema/wait_online.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Serialize};
+
+use crate::{JsonDisplay, NetworkState};
+
+const GATEWAY4: &str = "0.0.0.0/0";
+const GATEWAY6: &str = "::/0";
+
+/// Daemon wait online configuration
+///
+/// Configuration instructing when daemon should consider the network is
+/// online on boot.
+/// Once daemon reaches online state, it stop tracking whether online
+/// conditions still met. This is purely designed for systemd
+/// network-online.target.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonDisplay)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub struct NipartWaitOnline {
+    /// Maximum wait time in seconds to wait network state to be online.
+    /// Default is 30 seconds. Setting to 0 means mark as online once daemon
+    /// starts.
+    #[serde(default = "default_tmo")]
+    pub timeout_sec: u32,
+    /// The network is considered as online when all of these conditions met.
+    /// If undefined, daemon wait all saved configuration been applied.
+    /// If set to empty list explicitly, daemon will mark online once started.
+    #[serde(default = "default_conditions")]
+    pub conditions: Vec<NipartWaitOnlineCondition>,
+}
+
+fn default_tmo() -> u32 {
+    NipartWaitOnline::DEFAULT_TIMEOUT_SEC
+}
+
+fn default_conditions() -> Vec<NipartWaitOnlineCondition> {
+    vec![NipartWaitOnlineCondition::default()]
+}
+
+impl NipartWaitOnline {
+    pub const DEFAULT_TIMEOUT_SEC: u32 = 30;
+}
+
+impl Default for NipartWaitOnline {
+    fn default() -> Self {
+        Self {
+            timeout_sec: default_tmo(),
+            conditions: default_conditions(),
+        }
+    }
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Default, Deserialize, Serialize, JsonDisplay,
+)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum NipartWaitOnlineCondition {
+    /// IPv4 or IPv6 gateway added.
+    #[default]
+    Gateway,
+    /// IPv4 gateway added. (TODO: reachable via ARP?)
+    Gateway4,
+    /// IPv6 gateway added. (TODO: reachable via Neighbor Discovery?)
+    Gateway6,
+}
+
+impl NipartWaitOnlineCondition {
+    pub fn is_met(&self, cur_state: &NetworkState) -> bool {
+        match self {
+            Self::Gateway => {
+                cur_state.routes.running.as_ref().map(|rts| {
+                    rts.iter().any(|rt| {
+                        rt.destination.as_deref() == Some(GATEWAY4)
+                            || rt.destination.as_deref() == Some(GATEWAY6)
+                    })
+                }) == Some(true)
+            }
+            Self::Gateway4 => {
+                cur_state.routes.running.as_ref().map(|rts| {
+                    rts.iter()
+                        .any(|rt| rt.destination.as_deref() == Some(GATEWAY4))
+                }) == Some(true)
+            }
+            Self::Gateway6 => {
+                cur_state.routes.running.as_ref().map(|rts| {
+                    rts.iter()
+                        .any(|rt| rt.destination.as_deref() == Some(GATEWAY6))
+                }) == Some(true)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Introducing `nipart-wait-online.service` systemd service to wait nipartd
to configure the network and reach `online` state.

Example YAML for configuration for waiting IPv4 and IPv6 gateway
been set:

```yml
wait-online:
  timeout-sec: 30
  conditions:
    - gateway4
    - gateway6
```

The `wait-online` does not use partial updating, if defined, override
previous configuration, if undesired, use previously saved config or use
default config if no saved config:

```yml
wait-online:
  timeout-sec: 30
  conditions:
    - gateway
```

When all conditions met, daemon will consider the network is online and
`npt wait-online` command will quit with error 0.
When timeout, `npt wait-online` quit with error 124(this is the error
code returned in /usr/bin/timeout command).

Valid online conditions:
 * `saved-config-applied`: All saved configurations applied, but not
   including conditional activation interfaces.
 * `gateway`: IPv4 or IPv6 gateway added.
 * `gateway4`: IPv4 gateway added.
 * `gateway6`: IPv6 gateway added.

Once daemon reach online state, it will stop tracking follow up network
changes and will NOT check whether online conditions still met.
This is purely designed for systemd `network-online.target`.

No test case because too complex to write the test case for this stage
of project. Manually tested with ollama.service only been invoked after
nipartd applied config with gateway set.