### PR TITLE
daemon event: Should not trigger WIFI re-config when wifi-phy is up

### DIFF
--- a/src/daemon/event/event_worker.rs
+++ b/src/daemon/event/event_worker.rs
@@ -171,12 +171,17 @@ impl NipartEventWorker {
                 && let Some(Interface::WifiPhy(cur_wifi_iface)) = cur_iface
                 && cur_wifi_iface.ssid().is_some()
                 && let Interface::WifiCfg(saved_wifi_iface) = saved_iface
-                && cur_wifi_iface.ssid() == saved_wifi_iface.ssid()
             {
-                desired_state.ifaces.push(wifi_cfg_to_wifi_phy(
-                    event.iface_name.as_str(),
-                    saved_iface,
-                ));
+                if cur_wifi_iface.ssid() == saved_wifi_iface.ssid() {
+                    desired_state.ifaces.push(wifi_cfg_to_wifi_phy(
+                        event.iface_name.as_str(),
+                        saved_iface,
+                    ));
+                }
+                // Since the WIFI interface is already up, we should not
+                // try to configure more SSID on it which should be done
+                // at link_down event. Hence we continue regardless whether
+                // SSID match or not.
                 continue;
             }
 

--- a/src/lib/schema/ifaces/wireguard.rs
+++ b/src/lib/schema/ifaces/wireguard.rs
@@ -154,27 +154,23 @@ impl WireguardConfig {
                         iface_name,
                     ),
                 ));
-            } else {
-                if self.private_key.as_deref()
-                    == Some(crate::NetworkState::HIDE_SECRET_STR)
-                {
-                    return Err(NipartError::new(
-                        ErrorKind::InvalidArgument,
-                        format!(
-                            "Private key cannot be set to {}  for creating \
-                             new wireguard interface {}",
-                            crate::NetworkState::HIDE_SECRET_STR,
-                            iface_name,
-                        ),
-                    ));
-                }
-            }
-        } else {
-            if self.private_key.as_deref()
+            } else if self.private_key.as_deref()
                 == Some(crate::NetworkState::HIDE_SECRET_STR)
             {
-                self.private_key = None;
+                return Err(NipartError::new(
+                    ErrorKind::InvalidArgument,
+                    format!(
+                        "Private key cannot be set to {} for creating new \
+                         wireguard interface {}",
+                        crate::NetworkState::HIDE_SECRET_STR,
+                        iface_name,
+                    ),
+                ));
             }
+        } else if self.private_key.as_deref()
+            == Some(crate::NetworkState::HIDE_SECRET_STR)
+        {
+            self.private_key = None;
         }
 
         if let Some(peers) = self.peers.as_mut() {


### PR DESCRIPTION
When wifi-phy interface is UP, it means this WIFI SSID is connected, we
should not request more wifi-cfg config on other SSIDs.