### PR TITLE
wifi: Connect to BSSID with best signal

### DIFF
--- a/TODO
+++ b/TODO
@@ -11,5 +11,4 @@
  * IpVlan
 
  * Plugin cannot send back logs to user
- * WIFI should connect to AP with best signal
  * `nmc wifi connect` should wait connect and retry for wrong-password

--- a/src/lib/no_daemon/wifi/apply.rs
+++ b/src/lib/no_daemon/wifi/apply.rs
@@ -3,8 +3,11 @@
 use std::collections::{HashMap, HashSet};
 
 use super::{
-    NipartWpaConn, bss::WpaSupBss, dbus::NipartWpaSupDbus,
-    network::WpaSupNetwork, scan::bss_active_scan,
+    NipartWpaConn,
+    bss::{WpaSupBss, mac_to_string},
+    dbus::NipartWpaSupDbus,
+    network::WpaSupNetwork,
+    scan::bss_active_scan,
 };
 use crate::{
     ErrorKind, Interface, InterfaceType, MergedInterfaces, NipartError,
@@ -12,6 +15,19 @@ use crate::{
 };
 
 const MAX_SCAN_RETRY: usize = 5;
+
+/// Find the BSSID with the best signal strength for a given interface and SSID
+fn find_best_bss_by_signal<'a>(
+    existing_bsses: &'a HashMap<(String, String), WpaSupBss>,
+    iface_name: &str,
+    ssid: &str,
+) -> Option<&'a WpaSupBss> {
+    existing_bsses
+        .iter()
+        .filter(|((iface, s), _)| iface == iface_name && s == ssid)
+        .max_by_key(|(_, bss)| bss.signal_dbm.unwrap_or(i16::MIN))
+        .map(|(_, bss)| bss)
+}
 
 impl NipartWpaConn {
     pub(crate) async fn apply(
@@ -134,14 +150,14 @@ async fn add_networks(
     log::trace!("Got WIFI scan result: {existing_bsses:?}");
 
     for (iface_name, wifi_cfg) in wifi_cfg_to_add {
-        add_wifi_cfg(
-            iface_name,
-            wifi_cfg,
-            dbus,
+        // If BSSID is not specified, find the best BSSID by signal strength
+        let best_bss = if wifi_cfg.bssid.is_none() {
+            find_best_bss_by_signal(&existing_bsses, iface_name, &wifi_cfg.ssid)
+        } else {
             existing_bsses
-                .get(&(iface_name.to_string(), wifi_cfg.ssid.to_string())),
-        )
-        .await?;
+                .get(&(iface_name.to_string(), wifi_cfg.ssid.to_string()))
+        };
+        add_wifi_cfg(iface_name, wifi_cfg, dbus, best_bss).await?;
     }
     Ok(())
 }
@@ -212,10 +228,16 @@ async fn add_wifi_cfg(
         }
     };
 
+    // Use BSSID from user config if specified, otherwise use the one from scan
+    // result (best signal)
+    let selected_bssid = wifi_cfg.bssid.clone().or_else(|| {
+        bss.and_then(|b| b.bssid.as_ref().map(|v| mac_to_string(v.as_slice())))
+    });
+
     let mut wpa_network = WpaSupNetwork {
         ssid: ssid.to_string(),
         psk: wifi_cfg.password.clone(),
-        bssid: wifi_cfg.bssid.clone(),
+        bssid: selected_bssid,
         ..Default::default()
     };
     if let Some(bss) = bss

--- a/src/lib/no_daemon/wifi/bss.rs
+++ b/src/lib/no_daemon/wifi/bss.rs
@@ -183,7 +183,7 @@ impl TryFrom<zvariant::OwnedValue> for WpaSupBssRsn {
     }
 }
 
-fn mac_to_string(data: &[u8]) -> String {
+pub(crate) fn mac_to_string(data: &[u8]) -> String {
     let mut rt = String::new();
     for (i, m) in data.iter().enumerate() {
         write!(rt, "{m:02x}").ok();

--- a/src/lib/no_daemon/wifi/scan.rs
+++ b/src/lib/no_daemon/wifi/scan.rs
@@ -33,7 +33,7 @@ pub(crate) async fn bss_active_scan(
 ) -> Result<HashMap<(String, String), WpaSupBss>, NipartError> {
     // Interface name to dbus object path map
     let mut iface_obj_paths: HashMap<String, String> = HashMap::new();
-    // HashMap key is (iface_name, ssid)
+    // HashMap key is (iface_name, ssid) - stores best BSSID per SSID
     let mut ret: HashMap<(String, String), WpaSupBss> = HashMap::new();
 
     for iface in ifaces {


### PR DESCRIPTION
There is no way to instruct `mac80211_hwsim` generating two different
signal level, hence no CI test case.

Manually tested on my workstation with 3 APs providing same SSID service.