### PR TITLE
event: Add default 5 second debounce delay to prevent event bouncing

### DIFF
--- a/src/daemon/event/event_worker.rs
+++ b/src/daemon/event/event_worker.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{
+    collections::HashMap,
+    time::{Duration, Instant},
+};
+
 use futures_channel::{mpsc::UnboundedReceiver, oneshot::Sender};
 use nipart::{
     BaseInterface, ErrorKind, Interface, InterfaceIpv4, InterfaceIpv6,
@@ -45,6 +50,9 @@ type FromManager = (
 pub(crate) struct NipartEventWorker {
     receiver: UnboundedReceiver<FromManager>,
     commander: Option<NipartCommander>,
+    /// Tracks pending debounce events by interface name
+    /// Maps iface_name -> (desired_state, scheduled_execution_time)
+    pending_debounce: HashMap<String, (bool, Instant)>,
 }
 
 impl TaskWorker for NipartEventWorker {
@@ -57,6 +65,7 @@ impl TaskWorker for NipartEventWorker {
         Ok(Self {
             receiver,
             commander: None,
+            pending_debounce: HashMap::new(),
         })
     }
 
@@ -97,7 +106,52 @@ impl NipartEventWorker {
             ));
         };
         log::trace!("Handle link event {event}");
+
+        // Query saved state to check for trigger configuration
         let saved_state = commander.conf_manager.query_state().await?;
+
+        // Check debounce delay (defaults to 5 seconds if not configured)
+        let delay_secs = get_debounce_delay(&saved_state, &event.iface_name);
+
+        // Record this event as pending debounce
+        let event_time = Instant::now();
+        self.pending_debounce
+            .insert(event.iface_name.clone(), (event.is_up, event_time));
+
+        log::debug!(
+            "Debouncing event for {} with delay {}s",
+            event.iface_name,
+            delay_secs
+        );
+
+        // Wait for the debounce delay
+        tokio::time::sleep(Duration::from_secs(delay_secs)).await;
+
+        // Check if this event has been superseded by a newer one
+        if let Some((pending_state, pending_time)) =
+            self.pending_debounce.get(&event.iface_name)
+        {
+            // If the pending event is different or newer, skip this one
+            if *pending_state != event.is_up
+                || pending_time.elapsed() < Duration::from_secs(delay_secs)
+            {
+                log::debug!(
+                    "Event for {} superseded, skipping",
+                    event.iface_name
+                );
+                return Ok(());
+            }
+        }
+
+        // Remove from pending debounce
+        self.pending_debounce.remove(&event.iface_name);
+
+        // Re-query current state after delay to get stable state
+        log::trace!(
+            "Debounce delay expired for {}, processing event",
+            event.iface_name
+        );
+
         let cur_state =
             NipartNoDaemon::query_network_state(NipartQueryOption::running())
                 .await?;
@@ -228,6 +282,22 @@ impl NipartEventWorker {
     }
 }
 
+/// Returns the debounce delay in seconds.
+/// If a delay is explicitly configured in the trigger, uses that value.
+/// Otherwise, defaults to 5 seconds for all interface types to prevent
+/// rapid up/down event oscillations.
+fn get_debounce_delay(saved_state: &NetworkState, iface_name: &str) -> u64 {
+    const DEFAULT_DEBOUNCE_DELAY_SECS: u64 = 5;
+
+    saved_state
+        .ifaces
+        .iter()
+        .find(|iface| iface.name() == iface_name)
+        .and_then(|iface| iface.base_iface().trigger.as_ref())
+        .and_then(|trigger| trigger.delay())
+        .unwrap_or(DEFAULT_DEBOUNCE_DELAY_SECS)
+}
+
 fn gen_desired_iface_up(
     saved_iface: &Interface,
     saved_state: &NetworkState,
@@ -260,7 +330,7 @@ fn gen_desired_iface_down(
     saved_iface: &Interface,
 ) -> Interface {
     let mut desired_iface = saved_iface.clone();
-    if trigger != &InterfaceTrigger::Carrier
+    if !trigger.is_carrier()
         && saved_iface.iface_type() != &InterfaceType::WifiCfg
     {
         desired_iface.base_iface_mut().state = if saved_iface.is_virtual() {

--- a/src/daemon/monitor/monitor_manager.rs
+++ b/src/daemon/monitor/monitor_manager.rs
@@ -2,8 +2,7 @@
 
 use futures_channel::mpsc::UnboundedSender;
 use nipart::{
-    Interface, InterfaceTrigger, MergedNetworkState, NetworkState, NipartError,
-    NipartInterface,
+    Interface, MergedNetworkState, NetworkState, NipartError, NipartInterface,
 };
 
 use super::{
@@ -69,8 +68,12 @@ impl NipartMonitorManager {
         {
             if iface.is_absent() {
                 self.del_iface_from_monitor(iface.name()).await?;
-            } else if iface.base_iface().trigger.as_ref()
-                == Some(&InterfaceTrigger::Carrier)
+            } else if iface
+                .base_iface()
+                .trigger
+                .as_ref()
+                .map(|t| t.is_carrier())
+                .unwrap_or(false)
             {
                 self.add_iface_to_monitor(iface.name()).await?;
             }

--- a/src/lib/schema/trigger.rs
+++ b/src/lib/schema/trigger.rs
@@ -17,25 +17,60 @@ pub enum InterfaceTrigger {
     /// This is default value.
     #[default]
     OneShot,
-    // TODO: Support delay for up/down action to prevent flipping.
     /// Use link carrier to up and down the interface. In order
     /// to keep tracking future carrier changes of interface, only purge IP
     /// stack when carrier down.
-    Carrier,
+    /// Optional delay (in seconds) can be specified to debounce rapid
+    /// up/down transitions.
+    Carrier { delay: Option<u64> },
     /// Bring the interface up when connected to specified SSID.
     /// Bring the interface down when disconnected from specified SSID.
     /// String `*` means any SSID.
-    Wifi(Box<String>),
+    /// Optional delay (in seconds) can be specified to debounce rapid
+    /// up/down transitions.
+    Wifi {
+        ssid: Box<String>,
+        delay: Option<u64>,
+    },
     /// Bring the interface up when specified SSID disconnected.
     /// Bring the interface down when specified SSID connected.
     /// String `*` is not valid, should use `InterfaceTrigger::OneShot`
     /// with `state: down`.
-    WifiNot(Box<String>),
+    /// Optional delay (in seconds) can be specified to debounce rapid
+    /// up/down transitions.
+    WifiNot {
+        ssid: Box<String>,
+        delay: Option<u64>,
+    },
 }
 
 impl InterfaceTrigger {
+    /// Returns the debounce delay in seconds if configured.
+    pub fn delay(&self) -> Option<u64> {
+        match self {
+            Self::Carrier { delay } => *delay,
+            Self::Wifi { delay, .. } => *delay,
+            Self::WifiNot { delay, .. } => *delay,
+            _ => None,
+        }
+    }
+
+    /// Returns true if this is a Carrier trigger (with or without delay).
+    pub fn is_carrier(&self) -> bool {
+        matches!(self, Self::Carrier { .. })
+    }
+
     pub fn is_wifi(&self) -> bool {
-        matches!(self, Self::Wifi(_) | Self::WifiNot(_))
+        matches!(self, Self::Wifi { .. } | Self::WifiNot { .. })
+    }
+
+    /// Returns the SSID if this is a WiFi trigger.
+    pub fn ssid(&self) -> Option<&str> {
+        match self {
+            Self::Wifi { ssid, .. } => Some(ssid.as_str()),
+            Self::WifiNot { ssid, .. } => Some(ssid.as_str()),
+            _ => None,
+        }
     }
 
     /// Return `Some(true)` for interface should be up
@@ -49,7 +84,7 @@ impl InterfaceTrigger {
     ) -> Option<bool> {
         match self {
             Self::OneShot => None,
-            Self::Carrier => {
+            Self::Carrier { .. } => {
                 if let Some(cur_iface) =
                     cur_ifaces.get(iface_name, Some(iface_type))
                 {
@@ -70,7 +105,7 @@ impl InterfaceTrigger {
                     None
                 }
             }
-            Self::Wifi(ssid) => {
+            Self::Wifi { ssid, .. } => {
                 if cur_ifaces.iter().any(|cur_iface| {
                     if let Interface::WifiPhy(wifi_iface) = cur_iface {
                         wifi_iface.ssid() == Some(ssid.as_str())
@@ -83,7 +118,7 @@ impl InterfaceTrigger {
                     Some(false)
                 }
             }
-            Self::WifiNot(ssid) => {
+            Self::WifiNot { ssid, .. } => {
                 if cur_ifaces.iter().any(|cur_iface| {
                     if let Interface::WifiPhy(wifi_iface) = cur_iface {
                         wifi_iface.ssid() == Some(ssid.as_str())
@@ -111,15 +146,20 @@ impl<'de> Deserialize<'de> for InterfaceTrigger {
         let v = serde_json::Value::deserialize(deserializer)?;
         if let Some(obj) = v.as_object() {
             if let Some(v) = obj.get("wifi") {
-                Ok(Self::Wifi(Box::new(
-                    <String>::deserialize(v)
-                        .map_err(|e| serde::de::Error::custom(e.to_string()))?,
-                )))
+                let (ssid, delay) = parse_wifi_value::<D>(v)?;
+                Ok(Self::Wifi {
+                    ssid: Box::new(ssid),
+                    delay,
+                })
             } else if let Some(v) = obj.get("wifi-not") {
-                Ok(Self::WifiNot(Box::new(
-                    <String>::deserialize(v)
-                        .map_err(|e| serde::de::Error::custom(e.to_string()))?,
-                )))
+                let (ssid, delay) = parse_wifi_value::<D>(v)?;
+                Ok(Self::WifiNot {
+                    ssid: Box::new(ssid),
+                    delay,
+                })
+            } else if let Some(v) = obj.get("carrier") {
+                let delay = parse_carrier_value::<D>(v)?;
+                Ok(Self::Carrier { delay })
             } else {
                 Err(serde::de::Error::custom(format!(
                     "{error_msg_prefix}, but got {}",
@@ -131,7 +171,7 @@ impl<'de> Deserialize<'de> for InterfaceTrigger {
             }
         } else if let Some(obj_str) = v.as_str() {
             match obj_str {
-                "carrier" => Ok(Self::Carrier),
+                "carrier" => Ok(Self::Carrier { delay: None }),
                 "one-shot" => Ok(Self::OneShot),
                 v => Err(serde::de::Error::custom(format!(
                     "{error_msg_prefix}, but got {v}",
@@ -145,6 +185,52 @@ impl<'de> Deserialize<'de> for InterfaceTrigger {
     }
 }
 
+fn parse_wifi_value<'de, D>(
+    v: &serde_json::Value,
+) -> Result<(String, Option<u64>), D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(obj) = v.as_object() {
+        let ssid = obj
+            .get("ssid")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                serde::de::Error::custom(
+                    "WiFi trigger requires 'ssid' field".to_string(),
+                )
+            })?
+            .to_string();
+        let delay = obj.get("delay").and_then(|v| v.as_u64());
+        Ok((ssid, delay))
+    } else if let Some(s) = v.as_str() {
+        Ok((s.to_string(), None))
+    } else {
+        Err(serde::de::Error::custom(
+            "WiFi trigger value should be a string or object with 'ssid' and \
+             optional 'delay'"
+                .to_string(),
+        ))
+    }
+}
+
+fn parse_carrier_value<'de, D>(
+    v: &serde_json::Value,
+) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    if let Some(delay) = v.as_u64() {
+        Ok(Some(delay))
+    } else if v.is_null() {
+        Ok(None)
+    } else {
+        Err(serde::de::Error::custom(
+            "Carrier value should be a number or null".to_string(),
+        ))
+    }
+}
+
 impl Serialize for InterfaceTrigger {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -152,15 +238,55 @@ impl Serialize for InterfaceTrigger {
     {
         match self {
             Self::OneShot => serializer.serialize_str("one-shot"),
-            Self::Carrier => serializer.serialize_str("carrier"),
-            Self::Wifi(v) => {
+            Self::Carrier { delay } => {
+                if let Some(delay) = delay {
+                    let mut map = serializer.serialize_map(Some(1))?;
+                    map.serialize_entry("carrier", delay)?;
+                    map.end()
+                } else {
+                    serializer.serialize_str("carrier")
+                }
+            }
+            Self::Wifi { ssid, delay } => {
                 let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry("wifi", v)?;
+                if let Some(delay) = delay {
+                    let mut wifi_obj = serde_json::Map::new();
+                    wifi_obj.insert(
+                        "ssid".to_string(),
+                        serde_json::Value::String(ssid.to_string()),
+                    );
+                    wifi_obj.insert(
+                        "delay".to_string(),
+                        serde_json::Value::Number((*delay).into()),
+                    );
+                    map.serialize_entry(
+                        "wifi",
+                        &serde_json::Value::Object(wifi_obj),
+                    )?;
+                } else {
+                    map.serialize_entry("wifi", ssid)?;
+                }
                 map.end()
             }
-            Self::WifiNot(v) => {
+            Self::WifiNot { ssid, delay } => {
                 let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry("wifi-not", v)?;
+                if let Some(delay) = delay {
+                    let mut wifi_obj = serde_json::Map::new();
+                    wifi_obj.insert(
+                        "ssid".to_string(),
+                        serde_json::Value::String(ssid.to_string()),
+                    );
+                    wifi_obj.insert(
+                        "delay".to_string(),
+                        serde_json::Value::Number((*delay).into()),
+                    );
+                    map.serialize_entry(
+                        "wifi-not",
+                        &serde_json::Value::Object(wifi_obj),
+                    )?;
+                } else {
+                    map.serialize_entry("wifi-not", ssid)?;
+                }
                 map.end()
             }
         }


### PR DESCRIPTION
Add debounce mechanism to NipartEventWorker to prevent rapid up/down
event oscillations. All interface types now default to a 5 seconds delay
when no explicit delay is configured in the trigger.

Changes include:
- Add get_debounce_delay() function with 5 seconds default
- Convert trigger variants from tuple to struct syntax to support
  optional delay field (Carrier, Wifi, WifiNot)
- Add debounce tracking with HashMap in NipartEventWorker
- Update serialization/deserialization to handle new delay parameter
- Update monitor_manager.rs to use is_carrier() helper method